### PR TITLE
fix(menu): increase menu height so Quit button is interactive

### DIFF
--- a/ClaudeIsland/Core/NotchViewModel.swift
+++ b/ClaudeIsland/Core/NotchViewModel.swift
@@ -118,7 +118,7 @@ final class NotchViewModel {
             // Compact size for settings menu
             return CGSize(
                 width: min(screenRect.width * 0.4, 480),
-                height: 420 + screenSelector.expandedPickerHeight + soundSelector.expandedPickerHeight
+                height: 500 + screenSelector.expandedPickerHeight + soundSelector.expandedPickerHeight
             )
         case .instances:
             return CGSize(


### PR DESCRIPTION
## Summary

- Increase settings menu base height from 420px to 500px
- Fixes Quit button being unclickable due to falling outside interactive area

## Problem

The settings menu contains 13 items (pickers, toggles, dividers, and the Quit button). With VStack spacing and container padding, the total content height exceeds 420px, causing the Quit button at the bottom to be clipped from the interactive region.

## Solution

Increase the base menu height constant in `NotchViewModel.swift` from 420 to 500. The dynamic height additions for expanded pickers continue to work as before.

## References

- Upstream PR: farouqaldori/claude-island#21
- Upstream issue: farouqaldori/claude-island#20