### PR TITLE
fix: prevent spinner and checkmark clipping on collapsed notch

### DIFF
--- a/ClaudeIsland/UI/Views/NotchView.swift
+++ b/ClaudeIsland/UI/Views/NotchView.swift
@@ -311,11 +311,13 @@ struct NotchView: View {
                     ProcessingSpinner()
                         .matchedGeometryEffect(id: "spinner", in: self.activityNamespace, isSource: self.showClosedActivity)
                         .frame(width: self.viewModel.status == .opened ? 20 : self.sideWidth)
+                        .padding(.trailing, self.viewModel.status == .opened ? 0 : 4)
                 } else if self.hasWaitingForInput {
                     // Checkmark for waiting-for-input on the right side
                     ReadyForInputIndicatorIcon(size: 14, color: TerminalColors.green)
                         .matchedGeometryEffect(id: "spinner", in: self.activityNamespace, isSource: self.showClosedActivity)
                         .frame(width: self.viewModel.status == .opened ? 20 : self.sideWidth)
+                        .padding(.trailing, self.viewModel.status == .opened ? 0 : 4)
                 }
             }
         }


### PR DESCRIPTION
## Summary

- Add conditional trailing padding to right-side activity indicators (spinner and checkmark) when the notch is collapsed
- The NotchShape's curved top corners cause these indicators to be partially cut off in the collapsed state
- Applies 4pt padding when collapsed, 0pt when expanded

## Changes

Modified `ClaudeIsland/UI/Views/NotchView.swift`:
- Added `.padding(.trailing, self.viewModel.status == .opened ? 0 : 4)` to `ProcessingSpinner`
- Added `.padding(.trailing, self.viewModel.status == .opened ? 0 : 4)` to `ReadyForInputIndicatorIcon`

## Attribution

Based on [farouqaldori/claude-island#26](https://github.com/farouqaldori/claude-island/pull/26) by @saoudrizwan.

## Test plan

- [x] Build the app and launch it
- [x] Start a Claude Code session to trigger the processing spinner
- [x] Verify the spinner is fully visible on the collapsed notch
- [x] Let Claude finish to trigger the waiting-for-input checkmark
- [x] Verify the checkmark is fully visible without clipping