### PR TITLE
feat: add universal terminal focus without yabai dependency

### DIFF
--- a/ClaudeIsland/UI/Views/ChatView.swift
+++ b/ClaudeIsland/UI/Views/ChatView.swift
@@ -639,11 +639,13 @@ struct ChatView: View {
     }
 
     private func focusTerminal() {
-        if let pid = session.pid {
-            let success = TerminalFocuser.shared.focusTerminal(forClaudePID: pid)
-            if success { return }
+        Task {
+            if let pid = session.pid {
+                let success = await TerminalFocuser.shared.focusTerminal(forClaudePID: pid)
+                if success { return }
+            }
+            _ = await TerminalFocuser.shared.focusTerminal(forWorkingDirectory: self.session.cwd)
         }
-        _ = TerminalFocuser.shared.focusTerminal(forWorkingDirectory: self.session.cwd)
     }
 
     private func approvePermission() {

--- a/ClaudeIsland/UI/Views/ClaudeInstancesView.swift
+++ b/ClaudeIsland/UI/Views/ClaudeInstancesView.swift
@@ -98,11 +98,13 @@ struct ClaudeInstancesView: View {
     }
 
     private func focusSession(_ session: SessionState) {
-        if let pid = session.pid {
-            let success = TerminalFocuser.shared.focusTerminal(forClaudePID: pid)
-            if success { return }
+        Task {
+            if let pid = session.pid {
+                let success = await TerminalFocuser.shared.focusTerminal(forClaudePID: pid)
+                if success { return }
+            }
+            _ = await TerminalFocuser.shared.focusTerminal(forWorkingDirectory: session.cwd)
         }
-        _ = TerminalFocuser.shared.focusTerminal(forWorkingDirectory: session.cwd)
     }
 
     private func openChat(_ session: SessionState) {


### PR DESCRIPTION
## Summary

- Add `TerminalFocuser` service that uses `NSRunningApplication.activate()` to focus terminal apps
- Replace `YabaiController` usage with `TerminalFocuser` in `ClaudeInstancesView` and `ChatView`
- Show terminal button when session has a PID (not just for tmux sessions with yabai)
- Change focus icon from "eye" to "terminal"

## Details

The new `TerminalFocuser` walks up the process tree using the existing `ProcessTreeBuilder.findTerminalPID()` to find the parent terminal application, then activates it via `NSRunningApplication`. This works with Terminal.app, iTerm, Warp, Ghostty, and other terminals without requiring yabai to be installed.

Based on the approach from farouqaldori/claude-island PR #35, adapted to leverage existing infrastructure.

## Test plan

- [x] Run Claude Code in Terminal.app and verify the terminal icon appears
- [x] Click the terminal icon and verify Terminal.app is focused
- [x] Repeat with iTerm, Warp, or Ghostty if available
- [x] Verify fallback works when terminal detection fails