### PR TITLE
fix: prevent notification sound on subagent completion

### DIFF
--- a/ClaudeIsland/Resources/claude-island-state.py
+++ b/ClaudeIsland/Resources/claude-island-state.py
@@ -177,8 +177,8 @@ def main():
         state["status"] = "waiting_for_input"
 
     elif event == "SubagentStop":
-        # SubagentStop fires when a subagent completes - usually means back to waiting
-        state["status"] = "waiting_for_input"
+        # SubagentStop fires when a subagent completes - main session continues processing
+        state["status"] = "processing"
 
     elif event == "SessionStart":
         # New session starts waiting for user input


### PR DESCRIPTION
## Summary

- Fix notification sound incorrectly playing when subagents (Task tools) complete
- Change `SubagentStop` handler to report `status="processing"` instead of `"waiting_for_input"`

## Problem

When a subagent completes via `SubagentStop` event, the hook previously set `status="waiting_for_input"`. This triggered the notification sound even though the main Claude session was still actively processing (receiving the subagent result and continuing work).

## Solution

The main session continues processing after a subagent returns, so `SubagentStop` should report `"processing"` status. The notification sound will now only trigger when the main session actually finishes via the `Stop` event.

Based on: https://github.com/farouqaldori/claude-island/pull/37

## Test plan

- Start a Claude Code session that uses subagents (Task tools)
- Verify notification sound does NOT play when subagents complete
- Verify notification sound DOES play when the main session finishes and waits for input