### PR TITLE
fix: include tool_input in SessionStateDict literal for basedpyright

### DIFF
--- a/ClaudeIsland/Resources/claude-island-state.py
+++ b/ClaudeIsland/Resources/claude-island-state.py
@@ -119,12 +119,11 @@ class SessionState:
             "tty_valid": self.tty_valid,
             "session_active": self.session_active,
             "status": self.status,
+            "tool_input": self.tool_input,  # Required field - include in literal
         }
 
         if self.tool is not None:
             result["tool"] = self.tool
-        # Always include tool_input for backwards compatibility (even if empty)
-        result["tool_input"] = self.tool_input
         if self.tool_use_id is not None:
             result["tool_use_id"] = self.tool_use_id
         if self.notification_type is not None:


### PR DESCRIPTION
## Summary

- Fix basedpyright type error in `claude-island-state.py` by including `tool_input` in the initial `SessionStateDict` literal
- The field is required in the TypedDict, so it must be present in the literal rather than added afterward

## Test plan

- [x] Verify `uvx basedpyright@latest ClaudeIsland/Resources/claude-island-state.py` reports 0 errors