### PR TITLE
feat(ci): add CI workflow and VirusTotal scanning

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -18,6 +18,8 @@ jobs:
     steps:
       - name: Checkout repository
         uses: actions/checkout@v6
+        with:
+          ref: ${{ github.event.workflow_run.head_sha }}
 
       - name: Setup Xcode
         uses: maxim-lobanov/setup-xcode@v1
@@ -81,7 +83,13 @@ jobs:
           echo "Scan completed at: $(date -u '+%Y-%m-%d %H:%M:%S UTC')" >> virustotal-results.md
           echo "" >> virustotal-results.md
           echo "### Analysis URLs" >> virustotal-results.md
-          echo '${{ steps.virustotal.outputs.analysis }}' | jq -r 'to_entries[] | "- [\(.key)](\(.value))"' >> virustotal-results.md
+          # Output format is comma-separated "filename=url" pairs
+          IFS=',' read -ra PAIRS <<< "${{ steps.virustotal.outputs.analysis }}"
+          for pair in "${PAIRS[@]}"; do
+            filename="${pair%%=*}"
+            url="${pair#*=}"
+            echo "- [${filename}](${url})" >> virustotal-results.md
+          done
 
       - name: Upload scan results
         uses: actions/upload-artifact@v6

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -115,7 +115,13 @@ jobs:
           echo "Scan completed at: $(date -u '+%Y-%m-%d %H:%M:%S UTC')" >> virustotal-results.md
           echo "" >> virustotal-results.md
           echo "### Analysis URLs" >> virustotal-results.md
-          echo '${{ steps.virustotal.outputs.analysis }}' | jq -r 'to_entries[] | "- [\(.key)](\(.value))"' >> virustotal-results.md
+          # Output format is comma-separated "filename=url" pairs
+          IFS=',' read -ra PAIRS <<< "${{ steps.virustotal.outputs.analysis }}"
+          for pair in "${PAIRS[@]}"; do
+            filename="${pair%%=*}"
+            url="${pair#*=}"
+            echo "- [${filename}](${url})" >> virustotal-results.md
+          done
 
       - name: Upload scan results
         uses: actions/upload-artifact@v6


### PR DESCRIPTION
## Summary

- Add new CI workflow that triggers after Code Quality checks pass on main branch
- Add VirusTotal scanning to both CI and release workflows
- Upload scan results as workflow artifacts

## Changes

### New CI Workflow (`.github/workflows/ci.yml`)

Triggers via `workflow_run` after the Code Quality workflow completes successfully on `main`. This ensures builds only run for merged PRs that pass linting.

Jobs:
- **build**: Builds DMG with Sparkle signing, uploads artifact (30-day retention)
- **virustotal-scan**: Scans DMG and uploads results summary (90-day retention)

### Release Workflow Updates

Added `virustotal-scan` job that runs after the build job:
- Downloads DMG artifact
- Scans with VirusTotal API
- Generates markdown summary with analysis URLs

## Required Configuration

Add the `VT_API_KEY` secret to the repository with a VirusTotal API key.

## Test Plan

- [x] Verify CI workflow triggers after Code Quality passes on main
- [x] Verify DMG artifact is downloadable from workflow run
- [x] Verify VirusTotal scan results artifact is created
- [x] Test release workflow with a test tag