### PR TITLE
refactor: remove Mixpanel analytics integration

### DIFF
--- a/ClaudeIsland.xcodeproj/project.pbxproj
+++ b/ClaudeIsland.xcodeproj/project.pbxproj
@@ -7,7 +7,6 @@
 	objects = {
 
 /* Begin PBXBuildFile section */
-		FD0F42E72EE7ABA400980302 /* Mixpanel in Frameworks */ = {isa = PBXBuildFile; productRef = FD0F42E62EE7ABA400980302 /* Mixpanel */; };
 		FD0F42E82EE7ACA500980302 /* OcclusionKit in Frameworks */ = {isa = PBXBuildFile; productRef = FD0F42E92EE7ACA500980302 /* OcclusionKit */; };
 		FDA49F7D2EE11E3C00F9612E /* Markdown in Frameworks */ = {isa = PBXBuildFile; productRef = FD33FD722EDF32D7002A6548 /* Markdown */; };
 		FDA49F7E2EE11E3C00F9612E /* Sparkle in Frameworks */ = {isa = PBXBuildFile; productRef = FDA49F7F2EE11E3C00F9612E /* Sparkle */; };
@@ -43,7 +42,6 @@
 			isa = PBXFrameworksBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
-				FD0F42E72EE7ABA400980302 /* Mixpanel in Frameworks */,
 				FD0F42E82EE7ACA500980302 /* OcclusionKit in Frameworks */,
 				FDA49F7D2EE11E3C00F9612E /* Markdown in Frameworks */,
 				FDA49F7E2EE11E3C00F9612E /* Sparkle in Frameworks */,
@@ -91,7 +89,6 @@
 			packageProductDependencies = (
 				FD33FD722EDF32D7002A6548 /* Markdown */,
 				FDA49F7F2EE11E3C00F9612E /* Sparkle */,
-				FD0F42E62EE7ABA400980302 /* Mixpanel */,
 				FD0F42E92EE7ACA500980302 /* OcclusionKit */,
 			);
 			productName = ClaudeIsland;
@@ -125,7 +122,6 @@
 			packageReferences = (
 				FD33FD712EDF32D7002A6548 /* XCRemoteSwiftPackageReference "swift-markdown" */,
 				FDA49F802EE11E3C00F9612E /* XCRemoteSwiftPackageReference "Sparkle" */,
-				FD0F42E52EE7ABA400980302 /* XCRemoteSwiftPackageReference "mixpanel-swift" */,
 				FD0F42EA2EE7ACA500980302 /* XCRemoteSwiftPackageReference "OcclusionKit" */,
 			);
 			preferredProjectObjectVersion = 77;
@@ -373,14 +369,6 @@
 /* End XCConfigurationList section */
 
 /* Begin XCRemoteSwiftPackageReference section */
-		FD0F42E52EE7ABA400980302 /* XCRemoteSwiftPackageReference "mixpanel-swift" */ = {
-			isa = XCRemoteSwiftPackageReference;
-			repositoryURL = "https://github.com/mixpanel/mixpanel-swift";
-			requirement = {
-				branch = master;
-				kind = branch;
-			};
-		};
 		FD0F42EA2EE7ACA500980302 /* XCRemoteSwiftPackageReference "OcclusionKit" */ = {
 			isa = XCRemoteSwiftPackageReference;
 			repositoryURL = "https://github.com/akdoan1/OcclusionKit";
@@ -408,11 +396,6 @@
 /* End XCRemoteSwiftPackageReference section */
 
 /* Begin XCSwiftPackageProductDependency section */
-		FD0F42E62EE7ABA400980302 /* Mixpanel */ = {
-			isa = XCSwiftPackageProductDependency;
-			package = FD0F42E52EE7ABA400980302 /* XCRemoteSwiftPackageReference "mixpanel-swift" */;
-			productName = Mixpanel;
-		};
 		FD0F42E92EE7ACA500980302 /* OcclusionKit */ = {
 			isa = XCSwiftPackageProductDependency;
 			package = FD0F42EA2EE7ACA500980302 /* XCRemoteSwiftPackageReference "OcclusionKit" */;

--- a/ClaudeIsland/App/AppDelegate.swift
+++ b/ClaudeIsland/App/AppDelegate.swift
@@ -1,6 +1,4 @@
 import AppKit
-import IOKit
-import Mixpanel
 import os
 import Sparkle
 import SwiftUI
@@ -46,33 +44,6 @@ class AppDelegate: NSObject, NSApplicationDelegate {
             return
         }
 
-        Mixpanel.initialize(token: "49814c1436104ed108f3fc4735228496")
-
-        let distinctID = self.getOrCreateDistinctID()
-        // swiftformat:disable:next acronyms
-        Mixpanel.mainInstance().identify(distinctId: distinctID)
-
-        let version = Bundle.main.infoDictionary?["CFBundleShortVersionString"] as? String ?? "unknown"
-        let build = Bundle.main.infoDictionary?["CFBundleVersion"] as? String ?? "unknown"
-        let osVersion = Foundation.ProcessInfo.processInfo.operatingSystemVersionString
-
-        Mixpanel.mainInstance().registerSuperProperties([
-            "app_version": version,
-            "build_number": build,
-            "macos_version": osVersion,
-        ])
-
-        self.fetchAndRegisterClaudeVersion()
-
-        Mixpanel.mainInstance().people.set(properties: [
-            "app_version": version,
-            "build_number": build,
-            "macos_version": osVersion,
-        ])
-
-        Mixpanel.mainInstance().track(event: "App Launched")
-        Mixpanel.mainInstance().flush()
-
         HookInstaller.installIfNeeded()
         NSApplication.shared.setActivationPolicy(.accessory)
 
@@ -100,7 +71,6 @@ class AppDelegate: NSObject, NSApplicationDelegate {
         // Stop interrupt watchers
         InterruptWatcherManager.shared.stopAll()
 
-        Mixpanel.mainInstance().flush()
         self.updateCheckTimer?.invalidate()
         self.screenObserver = nil
     }
@@ -115,92 +85,6 @@ class AppDelegate: NSObject, NSApplicationDelegate {
 
     private func handleScreenChange() {
         _ = self.windowManager?.setupNotchWindow()
-    }
-
-    private func getOrCreateDistinctID() -> String {
-        let key = "mixpanel_distinct_id"
-
-        if let existingID = UserDefaults.standard.string(forKey: key) {
-            return existingID
-        }
-
-        let platformExpert = IOServiceGetMatchingService(
-            kIOMainPortDefault,
-            IOServiceMatching("IOPlatformExpertDevice")
-        )
-        defer { IOObjectRelease(platformExpert) }
-
-        if let uuid = IORegistryEntryCreateCFProperty(
-            platformExpert,
-            kIOPlatformUUIDKey as CFString,
-            kCFAllocatorDefault,
-            0
-        )?.takeRetainedValue() as? String {
-            UserDefaults.standard.set(uuid, forKey: key)
-            return uuid
-        }
-
-        let newID = UUID().uuidString
-        UserDefaults.standard.set(newID, forKey: key)
-        return newID
-    }
-
-    private func fetchAndRegisterClaudeVersion() {
-        let claudeProjectsDir = FileManager.default.homeDirectoryForCurrentUser
-            .appendingPathComponent(".claude/projects")
-
-        guard let projectDirs = try? FileManager.default.contentsOfDirectory(
-            at: claudeProjectsDir,
-            includingPropertiesForKeys: [.contentModificationDateKey],
-            options: .skipsHiddenFiles
-        )
-        else { return }
-
-        var latestFile: URL?
-        var latestDate: Date?
-
-        for projectDir in projectDirs {
-            guard let files = try? FileManager.default.contentsOfDirectory(
-                at: projectDir,
-                includingPropertiesForKeys: [.contentModificationDateKey],
-                options: .skipsHiddenFiles
-            )
-            else { continue }
-
-            for file in files where file.pathExtension == "jsonl" && !file.lastPathComponent.hasPrefix("agent-") {
-                if let attrs = try? file.resourceValues(forKeys: [.contentModificationDateKey]),
-                   let modDate = attrs.contentModificationDate {
-                    if let existingDate = latestDate {
-                        if modDate > existingDate {
-                            latestDate = modDate
-                            latestFile = file
-                        }
-                    } else {
-                        latestDate = modDate
-                        latestFile = file
-                    }
-                }
-            }
-        }
-
-        guard let jsonlFile = latestFile,
-              let handle = FileHandle(forReadingAtPath: jsonlFile.path)
-        else { return }
-        defer { try? handle.close() }
-
-        let data = handle.readData(ofLength: 8192)
-        guard let content = String(data: data, encoding: .utf8) else { return }
-
-        for line in content.components(separatedBy: .newlines) where !line.isEmpty {
-            guard let lineData = line.data(using: .utf8),
-                  let json = try? JSONSerialization.jsonObject(with: lineData) as? [String: Any],
-                  let version = json["version"] as? String
-            else { continue }
-
-            Mixpanel.mainInstance().registerSuperProperties(["claude_code_version": version])
-            Mixpanel.mainInstance().people.set(properties: ["claude_code_version": version])
-            return
-        }
     }
 
     private func ensureSingleInstance() -> Bool {

--- a/ClaudeIsland/Services/State/SessionStore.swift
+++ b/ClaudeIsland/Services/State/SessionStore.swift
@@ -10,7 +10,6 @@
 
 import Combine
 import Foundation
-import Mixpanel
 import os.log
 
 // Central state manager for all Claude sessions
@@ -247,13 +246,7 @@ actor SessionStore {
 
     private func processHookEvent(_ event: HookEvent) async {
         let sessionID = event.sessionID
-        let isNewSession = self.sessions[sessionID] == nil
         var session = self.sessions[sessionID] ?? self.createSession(from: event)
-
-        // Track new session in Mixpanel
-        if isNewSession {
-            Mixpanel.mainInstance().track(event: "Session Started")
-        }
 
         session.pid = event.pid
         if let pid = event.pid {

--- a/README.md
+++ b/README.md
@@ -64,15 +64,6 @@ Claude Island installs hooks into `~/.claude/hooks/` that communicate session st
 
 When Claude needs permission to run a tool, the notch expands with approve/deny buttons—no need to switch to the terminal.
 
-## Analytics
-
-Claude Island uses Mixpanel to collect anonymous usage data:
-
-- **App Launched** — App version, build number, macOS version
-- **Session Started** — When a new Claude Code session is detected
-
-No personal data or conversation content is collected.
-
 ## License
 
 Apache 2.0


### PR DESCRIPTION
## Summary

- Remove Mixpanel SDK and all analytics tracking code
- Remove Mixpanel package dependency from Xcode project
- Update README to remove Analytics section

## Changes

**AppDelegate.swift**
- Remove `import IOKit` and `import Mixpanel`
- Remove Mixpanel initialization, identification, and tracking calls
- Remove `getOrCreateDistinctID()` and `fetchAndRegisterClaudeVersion()` helper methods

**SessionStore.swift**
- Remove `import Mixpanel`
- Remove session started tracking

**project.pbxproj**
- Remove all Mixpanel package references (build file, framework, product dependency, remote package reference)

**README.md**
- Remove Analytics documentation section

## Test plan

- [x] Build succeeds with `xcodebuild -scheme ClaudeIsland -configuration Release build`
- [x] All pre-commit hooks pass (swiftformat, swiftlint, shellcheck, ruff, markdownlint)
- [x] App launches without crashes
- [x] Session monitoring works correctly
- [x] Permission requests display and function correctly