### PR TITLE
feat(ci): display VirusTotal results in GitHub Actions summary

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -86,6 +86,8 @@ jobs:
             echo ""
             echo "### Analysis Reports"
             echo ""
+            echo "| File | Report |"
+            echo "|------|--------|"
             # Output format is comma-separated "filename=url" pairs
             IFS=',' read -ra PAIRS <<< "${{ steps.virustotal.outputs.analysis }}"
             for pair in "${PAIRS[@]}"; do

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -132,6 +132,8 @@ jobs:
             echo ""
             echo "### Analysis Reports"
             echo ""
+            echo "| File | Report |"
+            echo "|------|--------|"
             # Output format is comma-separated "filename=url" pairs
             IFS=',' read -ra PAIRS <<< "${{ steps.virustotal.outputs.analysis }}"
             for pair in "${PAIRS[@]}"; do


### PR DESCRIPTION
## Summary

- Write VirusTotal scan results to `$GITHUB_STEP_SUMMARY` in both CI and Release workflows
- Results now appear directly in the workflow run summary page
- Artifact upload retained for archival purposes

## Test plan

- [x] Push to main branch to trigger CI workflow
- [x] Verify the Summary tab shows VirusTotal scan results section
- [x] Verify the VirusTotal report link is clickable and functional
- [x] Verify the `virustotal-results` artifact is still uploaded