### PR TITLE
feat(ci): trigger website appcast update on release

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -76,8 +76,13 @@ jobs:
 
           # Extract signature from generated appcast
           if [ -f "releases/appcast/appcast.xml" ]; then
-            SIG=$(grep -oE 'sparkle:edSignature="[^"]+"' releases/appcast/appcast.xml | head -1 | sed 's/sparkle:edSignature="//;s/"$//')
-            echo "signature=$SIG" >> $GITHUB_OUTPUT
+            # Use grep with || true to avoid pipefail failure when no match exists
+            SIG=$(grep -oE 'sparkle:edSignature="[^"]+"' releases/appcast/appcast.xml 2>/dev/null | head -1 | sed 's/sparkle:edSignature="//;s/"$//' || true)
+            if [ -n "$SIG" ]; then
+              echo "signature=$SIG" >> $GITHUB_OUTPUT
+            else
+              echo "⚠️ No EdDSA signature found in appcast.xml"
+            fi
           fi
 
           # Get minimum system version from Info.plist
@@ -188,7 +193,8 @@ jobs:
     name: Update Website Appcast
     needs: build
     runs-on: ubuntu-latest
-    if: needs.build.outputs.has_sparkle == 'true'
+    # Only run if Sparkle signing was configured AND signature was actually generated
+    if: needs.build.outputs.has_sparkle == 'true' && needs.build.outputs.ed_signature != ''
 
     steps:
       - name: Trigger website appcast update


### PR DESCRIPTION
## Summary
- Add a new `update-website` job to the release workflow that triggers an appcast update on the website repository when a release is created
- Extract DMG metadata (size, EdDSA signature, minimum system version) during build and pass to the website update job
- Display build info in the GitHub Actions summary when Sparkle signing is available

## Details
The workflow uses `repository-dispatch` to notify `engels74/claude-island-web` with the release metadata needed to regenerate the Sparkle appcast XML. This automates the previously manual step of updating the website after each release.

The update only triggers when Sparkle signing is configured (`has_sparkle == true`), ensuring the signature is available for the appcast.

## Test plan
- [x] Verify workflow syntax is valid
- [x] Test with a release to confirm the dispatch event is sent
- [x] Verify the website repository receives the payload and updates the appcast