### PR TITLE
feat(ci): enable auto-generated release notes

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -131,6 +131,7 @@ jobs:
         with:
           tag_name: v${{ steps.version.outputs.version }}
           files: releases/ClaudeIsland-${{ steps.version.outputs.version }}.dmg
+          generate_release_notes: true
           body: |
             ## Claude Island v${{ steps.version.outputs.version }}
 


### PR DESCRIPTION
## Summary

- Adds `generate_release_notes: true` to the GitHub release action
- Release body now includes auto-generated "What's Changed" section with PR and commit links
- Auto-generated content appears after the installation instructions template

## Test plan

- [x] Push a new version tag and verify release notes include both the template and auto-generated changelog