### PR TITLE
feat(ci): support semver tags without v prefix

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -2,7 +2,7 @@ name: Build and Release
 
 on:
   push:
-    tags: ['v*', '[0-9]+.[0-9]+.[0-9]+']
+    tags: ['v*', '[0-9]*.[0-9]*.[0-9]*']
   workflow_dispatch:
     inputs:
       version:


### PR DESCRIPTION
## Summary

Updates the release workflow to trigger on both v-prefixed tags (e.g., `v1.3.0`) and strict semver tags (e.g., `1.3.0`).

## Changes

- Added `[0-9]+.[0-9]+.[0-9]+` pattern to the tag trigger in `release.yml`
- Maintains backward compatibility with existing `v*` pattern

## Test plan

- [x] Verified workflow syntax with `check yaml` pre-commit hook
- [ ] Test by pushing a semver tag without v prefix