### PR TITLE
Fix duplicate hook entries when migrating from original app

### DIFF
--- a/ClaudeIsland/Services/Hooks/HookInstaller.swift
+++ b/ClaudeIsland/Services/Hooks/HookInstaller.swift
@@ -224,56 +224,13 @@ enum HookInstaller {
         }
 
         // First, remove any legacy direct format entries (not wrapped in "hooks")
-        existingEvent.removeAll { entry in
-            self.isLegacyDirectEntry(entry)
-        }
+        existingEvent.removeAll { self.isLegacyDirectEntry($0) }
 
-        // Track seen matchers for claude-island hooks to deduplicate
-        // Empty string represents entries without a matcher
-        var seenMatchers = Set<String>()
-        var indicesToRemove = [Int]()
-
-        for i in existingEvent.indices {
-            var entry = existingEvent[i]
-            if var entryHooks = entry["hooks"] as? [[String: Any]] {
-                let isClaudeIslandEntry = entryHooks.contains { hook in
-                    if let cmd = hook["command"] as? String {
-                        return cmd.contains("claude-island-state.py")
-                    }
-                    return false
-                }
-
-                if isClaudeIslandEntry {
-                    let matcherKey = (entry["matcher"] as? String) ?? ""
-
-                    if seenMatchers.contains(matcherKey) {
-                        // Duplicate entry with same matcher - mark for removal
-                        indicesToRemove.append(i)
-                    } else {
-                        // First occurrence - update command and track matcher
-                        seenMatchers.insert(matcherKey)
-                        for j in entryHooks.indices {
-                            var hook = entryHooks[j]
-                            if let cmd = hook["command"] as? String,
-                               cmd.contains("claude-island-state.py") {
-                                hook["command"] = command
-                                entryHooks[j] = hook
-                            }
-                        }
-                        entry["hooks"] = entryHooks
-                        existingEvent[i] = entry
-                    }
-                }
-            }
-        }
-
-        // Remove duplicates in reverse order to preserve indices
-        if !indicesToRemove.isEmpty {
-            logger.info("Removed \(indicesToRemove.count) duplicate claude-island hook(s) from \(eventName)")
-            for index in indicesToRemove.reversed() {
-                existingEvent.remove(at: index)
-            }
-        }
+        // Deduplicate and update claude-island entries, preserving user hooks
+        let (updatedEntries, seenMatchers) = self.deduplicateClaudeIslandEntries(
+            in: existingEvent, command: command, eventName: eventName
+        )
+        existingEvent = updatedEntries
 
         // Add any missing configurations (matchers not already present)
         for configEntry in config {
@@ -284,6 +241,84 @@ enum HookInstaller {
         }
 
         return existingEvent
+    }
+
+    /// Deduplicate claude-island entries by matcher, merging user hooks from duplicates
+    /// Returns updated entries and set of seen matchers
+    private static func deduplicateClaudeIslandEntries(
+        in entries: [[String: Any]],
+        command: String,
+        eventName: String
+    ) -> ([[String: Any]], Set<String>) {
+        var result = entries
+        var matcherToFirstIndex: [String: Int] = [:]
+        var indicesToRemove = [Int]()
+
+        for i in result.indices {
+            guard var entryHooks = result[i]["hooks"] as? [[String: Any]],
+                  self.isClaudeIslandHookEntry(entryHooks)
+            else { continue }
+
+            let matcherKey = (result[i]["matcher"] as? String) ?? ""
+
+            if let firstIndex = matcherToFirstIndex[matcherKey] {
+                // Duplicate - merge user hooks into first entry, then mark for removal
+                self.mergeUserHooks(from: entryHooks, into: &result, at: firstIndex, eventName: eventName)
+                indicesToRemove.append(i)
+            } else {
+                // First occurrence - update command and track matcher
+                matcherToFirstIndex[matcherKey] = i
+                self.updateClaudeIslandCommand(in: &entryHooks, to: command)
+                result[i]["hooks"] = entryHooks
+            }
+        }
+
+        // Remove duplicates in reverse order to preserve indices
+        if !indicesToRemove.isEmpty {
+            logger.info("Removed \(indicesToRemove.count) duplicate claude-island hook entry(ies) from \(eventName)")
+            for index in indicesToRemove.reversed() {
+                result.remove(at: index)
+            }
+        }
+
+        return (result, Set(matcherToFirstIndex.keys))
+    }
+
+    /// Check if hooks array contains a claude-island hook
+    private static func isClaudeIslandHookEntry(_ hooks: [[String: Any]]) -> Bool {
+        hooks.contains { hook in
+            (hook["command"] as? String)?.contains("claude-island-state.py") == true
+        }
+    }
+
+    /// Merge non-claude-island hooks from source into the target entry
+    private static func mergeUserHooks(
+        from sourceHooks: [[String: Any]],
+        into entries: inout [[String: Any]],
+        at targetIndex: Int,
+        eventName: String
+    ) {
+        let userHooks = sourceHooks.filter { hook in
+            guard let cmd = hook["command"] as? String else { return true }
+            return !cmd.contains("claude-island-state.py")
+        }
+
+        guard !userHooks.isEmpty,
+              var targetHooks = entries[targetIndex]["hooks"] as? [[String: Any]]
+        else { return }
+
+        targetHooks.append(contentsOf: userHooks)
+        entries[targetIndex]["hooks"] = targetHooks
+        logger.info("Merged \(userHooks.count) user hook(s) from duplicate entry in \(eventName)")
+    }
+
+    /// Update claude-island command in hooks array
+    private static func updateClaudeIslandCommand(in hooks: inout [[String: Any]], to command: String) {
+        for j in hooks.indices {
+            if let cmd = hooks[j]["command"] as? String, cmd.contains("claude-island-state.py") {
+                hooks[j]["command"] = command
+            }
+        }
     }
 
     /// Check if entry is a legacy direct format (type: command at top level, not wrapped in hooks)


### PR DESCRIPTION
## Summary

- Fixes duplicate claude-island hook entries in `~/.claude/settings.json` that can occur when users migrate from the original ItsNarciz claude-island app
- Deduplicates hooks by matcher value, keeping the first occurrence and removing subsequent duplicates
- Preserves PreCompact entries with different matchers (auto/manual) as distinct entries
- Logs removal count when duplicates are cleaned up

## Test plan

- [x] Fresh install: Launch app with no `~/.claude/settings.json` and verify hooks are created correctly
- [x] Duplicate cleanup: Manually add duplicate hook entries, launch app, verify deduplication occurs
- [x] PreCompact preservation: Verify both `auto` and `manual` matchers are preserved
- [x] User hooks: Add custom user hooks and verify they remain untouched after app launch
- [x] Console logging: Check Console.app for "Removed X duplicate" log messages

Closes #45