### PR TITLE
Fix accessibility permissions not working with ad-hoc signed apps

### DIFF
--- a/ClaudeIsland/App/AppDelegate.swift
+++ b/ClaudeIsland/App/AppDelegate.swift
@@ -128,10 +128,11 @@ class AppDelegate: NSObject, NSApplicationDelegate {
 
     private func checkAccessibilityPermission() {
         // Log diagnostic info for debugging TCC issues with ad-hoc signed apps
+        // Use .public privacy since these are needed for debugging and don't contain user data
         let bundlePath = Bundle.main.bundlePath
         let bundleID = Bundle.main.bundleIdentifier ?? "unknown"
-        logger.info("App launched from: \(bundlePath)")
-        logger.info("Bundle ID: \(bundleID)")
+        logger.info("App launched from: \(bundlePath, privacy: .public)")
+        logger.info("Bundle ID: \(bundleID, privacy: .public)")
 
         let manager = AccessibilityPermissionManager.shared
 

--- a/ClaudeIsland/Core/AccessibilityPermissionManager.swift
+++ b/ClaudeIsland/Core/AccessibilityPermissionManager.swift
@@ -37,9 +37,9 @@ final class AccessibilityPermissionManager {
         let newState = AXIsProcessTrusted()
         self.isAccessibilityEnabled = newState
 
-        // Log bundle path for debugging TCC issues
+        // Log bundle path for debugging TCC issues (use .public privacy for diagnostic visibility)
         let bundlePath = Bundle.main.bundlePath
-        logger.info("Accessibility check: AXIsProcessTrusted() = \(newState), bundle: \(bundlePath)")
+        logger.info("Accessibility check: AXIsProcessTrusted() = \(newState), bundle: \(bundlePath, privacy: .public)")
 
         // Log state changes prominently
         if previousState != newState {
@@ -103,9 +103,9 @@ final class AccessibilityPermissionManager {
     /// Returns true if user clicked "Open Settings", false if they clicked "Later"
     @discardableResult
     func showPermissionAlert() -> Bool {
-        // Log diagnostic info for debugging TCC issues
+        // Log diagnostic info for debugging TCC issues (use .public privacy for diagnostic visibility)
         let bundlePath = Bundle.main.bundlePath
-        logger.info("Showing permission alert. Bundle path: \(bundlePath)")
+        logger.info("Showing permission alert. Bundle path: \(bundlePath, privacy: .public)")
 
         // CRITICAL: Before showing modal alert, hide the notch window
         // The notch window sits at a high window level and visually blocks the alert
@@ -124,7 +124,7 @@ final class AccessibilityPermissionManager {
         To grant permission:
         1. Click "Open Settings" below
         2. Click the "+" button at the bottom of the list
-        3. Navigate to Applications and select "Claude Island"
+        3. Navigate to and select the Claude Island app bundle
         4. Enable the checkbox next to Claude Island
 
         Important: If Claude Island is already in the list but not working, \


### PR DESCRIPTION
## Summary

- Remove `promptForPermission()` method that used `AXIsProcessTrustedWithOptions`, which creates TCC entries incompatible with ad-hoc signed apps
- Update the permission alert to guide users through manually adding the app via the "+" button in System Settings Accessibility pane
- Add diagnostic logging of bundle path and bundle ID for debugging TCC-related issues

## Background

When `AXIsProcessTrustedWithOptions` auto-adds an entry to the TCC database, it creates a strict `csreq` (code signing requirement) that includes the exact ad-hoc signature hash. This entry fails to match after rebuilds or updates because ad-hoc signatures are not stable across builds.

When users manually add the app via the "+" button, macOS creates a more permissive TCC entry that works reliably with ad-hoc signed applications.

## Test plan

- [x] Fresh install: Remove any existing Claude Island entries from Accessibility settings, launch app, verify alert appears with manual-add instructions
- [x] Follow the "+" button instructions and confirm permission is granted and detected
- [x] If an auto-added entry exists from previous versions, verify the alert instructs to remove and re-add it
- [x] Check Console.app logs for bundle path and permission status on startup