### PR TITLE
Fix Sparkle version comparison by passing build_number to appcast

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -18,6 +18,7 @@ jobs:
 
     outputs:
       version: ${{ steps.version.outputs.version }}
+      build_number: ${{ steps.version-update.outputs.build_number }}
       dmg_size: ${{ steps.dmg-info.outputs.size }}
       ed_signature: ${{ steps.dmg-info.outputs.signature }}
       min_system: ${{ steps.dmg-info.outputs.min_system }}
@@ -43,6 +44,7 @@ jobs:
           fi
 
       - name: Update Xcode project version and commit
+        id: version-update
         run: |
           VERSION="${{ steps.version.outputs.version }}"
           BUILD_NUMBER="$(date +%Y%m%d%H%M)"
@@ -55,6 +57,7 @@ jobs:
           sed -i '' "s/CURRENT_PROJECT_VERSION = .*;/CURRENT_PROJECT_VERSION = $BUILD_NUMBER;/g" ClaudeIsland.xcodeproj/project.pbxproj
 
           echo "✅ Set MARKETING_VERSION=$VERSION, CURRENT_PROJECT_VERSION=$BUILD_NUMBER"
+          echo "build_number=$BUILD_NUMBER" >> $GITHUB_OUTPUT
 
           # Commit version changes back to repository
           if git diff --quiet ClaudeIsland.xcodeproj/project.pbxproj; then
@@ -269,6 +272,7 @@ jobs:
           client-payload: |
             {
               "version": "${{ needs.build.outputs.version }}",
+              "build_number": "${{ needs.build.outputs.build_number }}",
               "download_url": "https://github.com/engels74/claude-island/releases/download/${{ needs.build.outputs.version }}/ClaudeIsland-${{ needs.build.outputs.version }}.dmg",
               "ed_signature": "${{ needs.build.outputs.ed_signature }}",
               "file_size": "${{ needs.build.outputs.dmg_size }}",


### PR DESCRIPTION
## Summary

Sparkle compares `sparkle:version` from the appcast against `CFBundleVersion` from the app. The app uses timestamp build numbers (e.g., `202601241241`) but the appcast was using semver (e.g., `1.3.5`), causing false "You're up to date" messages.

This PR adds `build_number` to the job outputs and dispatch payload so the website can use it for `sparkle:version`.

## Changes

- Add `id: version-update` to capture build number output
- Add `build_number` to job outputs
- Include `build_number` in the dispatch payload to the website

## Related

Requires corresponding change in claude-island-web to consume the build_number.