### PR TITLE
Fix Swift 6 actor isolation crash in AnyCodable decoding

### DIFF
--- a/ClaudeIsland/Services/Hooks/HookSocketServer.swift
+++ b/ClaudeIsland/Services/Hooks/HookSocketServer.swift
@@ -921,12 +921,12 @@ struct AnyCodable: Codable, @unchecked Sendable {
     // MARK: Lifecycle
 
     /// Initialize with any value
-    init(_ value: Any) {
+    nonisolated init(_ value: Any) {
         self.value = value
     }
 
     /// Decode from JSON
-    init(from decoder: Decoder) throws {
+    nonisolated init(from decoder: Decoder) throws {
         let container = try decoder.singleValueContainer()
 
         if container.decodeNil() {
@@ -956,7 +956,7 @@ struct AnyCodable: Codable, @unchecked Sendable {
     nonisolated(unsafe) let value: Any
 
     /// Encode to JSON
-    func encode(to encoder: Encoder) throws {
+    nonisolated func encode(to encoder: Encoder) throws {
         var container = encoder.singleValueContainer()
 
         switch value {


### PR DESCRIPTION
## Summary

- Add `nonisolated` markers to `AnyCodable` Codable conformance methods to fix actor isolation crashes in Swift 6

## Details

The `AnyCodable` struct is marked as `@unchecked Sendable` with a `nonisolated(unsafe)` stored property. In Swift 6 strict concurrency mode, the Codable protocol methods (`init(from:)` and `encode(to:)`) and the convenience initializer need explicit `nonisolated` markers to prevent actor isolation violations when decoding occurs across different isolation contexts.

Without these markers, the Swift 6 compiler can incorrectly infer isolation requirements, causing runtime crashes when hook events are decoded on background threads.

## Test plan

- [x] Build with Swift 6 strict concurrency enabled
- [ ] Verify hook events are received and decoded without crashes
- [ ] Test with multiple concurrent Claude Code sessions