### PR TITLE
Suppress accessibility warning for debug builds

### DIFF
--- a/ClaudeIsland/App/AppDelegate.swift
+++ b/ClaudeIsland/App/AppDelegate.swift
@@ -136,7 +136,7 @@ class AppDelegate: NSObject, NSApplicationDelegate {
 
         let manager = AccessibilityPermissionManager.shared
 
-        if !manager.isAccessibilityEnabled {
+        if manager.shouldShowPermissionWarning {
             logger.warning("Accessibility permission not granted on launch")
 
             // Start periodic monitoring so UI updates when permission is granted

--- a/ClaudeIsland/UI/Views/NotchMenuView.swift
+++ b/ClaudeIsland/UI/Views/NotchMenuView.swift
@@ -440,7 +440,7 @@ struct AccessibilityRow: View {
 
             Spacer()
 
-            if self.accessibilityManager.isAccessibilityEnabled {
+            if !self.accessibilityManager.shouldShowPermissionWarning {
                 Circle()
                     .fill(TerminalColors.green)
                     .frame(width: 6, height: 6)
@@ -477,7 +477,7 @@ struct AccessibilityRow: View {
     @State private var isHovered = false
 
     private var textColor: Color {
-        if !self.accessibilityManager.isAccessibilityEnabled {
+        if self.accessibilityManager.shouldShowPermissionWarning {
             return TerminalColors.amber.opacity(self.isHovered ? 1.0 : 0.8)
         }
         return .white.opacity(self.isHovered ? 1.0 : 0.7)

--- a/ClaudeIsland/UI/Views/NotchView.swift
+++ b/ClaudeIsland/UI/Views/NotchView.swift
@@ -75,7 +75,7 @@ struct NotchView: View {
                     .animation(.smooth, value: self.activityCoordinator.expandingActivity)
                     .animation(.smooth, value: self.hasPendingPermission)
                     .animation(.smooth, value: self.hasWaitingForInput)
-                    .animation(.smooth, value: self.accessibilityManager.isAccessibilityEnabled)
+                    .animation(.smooth, value: self.accessibilityManager.shouldShowPermissionWarning)
                     .animation(.spring(response: 0.3, dampingFraction: 0.5), value: self.isBouncing)
                     .contentShape(Rectangle())
                     .onHover { hovering in
@@ -111,13 +111,13 @@ struct NotchView: View {
             self.handleProcessingChange()
             self.handleWaitingForInputChange(instances)
         }
-        .onChange(of: self.accessibilityManager.isAccessibilityEnabled) { _, isEnabled in
+        .onChange(of: self.accessibilityManager.shouldShowPermissionWarning) { _, shouldShow in
             // Keep notch visible while accessibility warning is shown
-            if !isEnabled {
+            if shouldShow {
                 self.isVisible = true
                 self.hideVisibilityTask?.cancel()
             } else {
-                // Permission granted, trigger normal visibility logic
+                // Warning dismissed, trigger normal visibility logic
                 self.handleProcessingChange()
             }
         }
@@ -196,7 +196,7 @@ struct NotchView: View {
 
     /// Whether accessibility permission is missing (show warning icon)
     private var needsAccessibilityWarning: Bool {
-        !self.accessibilityManager.isAccessibilityEnabled
+        self.accessibilityManager.shouldShowPermissionWarning
     }
 
     // MARK: - Sizing


### PR DESCRIPTION
## Summary

TCC (Transparency, Consent, and Control) stores permissions by code signature, not just app name. When running from Xcode:

- Installed app: `/Applications/Claude Island.app` (signed with certificate)
- Debug build: `~/Library/Developer/Xcode/DerivedData/.../Debug/Claude Island.app` (ad-hoc signed)

These are **different identities** to macOS, so granting permission to the installed app doesn't affect the debug build. This causes the accessibility warning triangle to show during development even when the installed app has permission granted.

This PR suppresses the misleading warning for debug builds by detecting when running from Xcode's DerivedData.

## Changes

- Add `isDebugBuild` property that detects `DerivedData` or `Build/Products/Debug` in bundle path
- Update `checkPermission()` to report `true` for debug builds (suppressing the warning)
- Enhance logging to show both actual `AXIsProcessTrusted()` result and effective value