### PR TITLE
Fix review issues from #58

### DIFF
--- a/ClaudeIsland/Core/SessionMetadataManager.swift
+++ b/ClaudeIsland/Core/SessionMetadataManager.swift
@@ -10,18 +10,18 @@ import SwiftUI
 @Observable
 @MainActor
 final class SessionMetadataManager {
+    // MARK: Lifecycle
+
+    private init() {
+        self.loadFromDefaults()
+    }
+
+    // MARK: Internal
+
     static let shared = SessionMetadataManager()
 
     private(set) var sessionColors: [String: String] = [:]
     private(set) var sessionNames: [String: String] = [:]
-
-    private let defaults = UserDefaults.standard
-    private let colorsKey = "sessionColors"
-    private let namesKey = "sessionNames"
-
-    private init() {
-        loadFromDefaults()
-    }
 
     func color(for sessionID: String) -> Color? {
         guard let hex = sessionColors[sessionID] else { return nil }
@@ -29,57 +29,54 @@ final class SessionMetadataManager {
     }
 
     func name(for sessionID: String) -> String? {
-        sessionNames[sessionID]
+        self.sessionNames[sessionID]
     }
 
     func setColor(_ hex: String?, for sessionID: String) {
         if let hex {
-            sessionColors[sessionID] = hex
+            self.sessionColors[sessionID] = hex
         } else {
-            sessionColors.removeValue(forKey: sessionID)
+            self.sessionColors.removeValue(forKey: sessionID)
         }
-        saveColors()
+        self.saveColors()
     }
 
     func setName(_ name: String?, for sessionID: String) {
         if let name, !name.trimmingCharacters(in: .whitespaces).isEmpty {
-            sessionNames[sessionID] = name
+            self.sessionNames[sessionID] = name
         } else {
-            sessionNames.removeValue(forKey: sessionID)
+            self.sessionNames.removeValue(forKey: sessionID)
         }
-        saveNames()
+        self.saveNames()
     }
 
-    func clearMetadata(for sessionID: String) {
-        sessionColors.removeValue(forKey: sessionID)
-        sessionNames.removeValue(forKey: sessionID)
-        saveColors()
-        saveNames()
-    }
+    // MARK: Private
+
+    private let defaults = UserDefaults.standard
+    private let colorsKey = "sessionColors"
+    private let namesKey = "sessionNames"
 
     private func loadFromDefaults() {
         if let colorsData = defaults.data(forKey: colorsKey),
-           let colors = try? JSONDecoder().decode([String: String].self, from: colorsData)
-        {
-            sessionColors = colors
+           let colors = try? JSONDecoder().decode([String: String].self, from: colorsData) {
+            self.sessionColors = colors
         }
 
         if let namesData = defaults.data(forKey: namesKey),
-           let names = try? JSONDecoder().decode([String: String].self, from: namesData)
-        {
-            sessionNames = names
+           let names = try? JSONDecoder().decode([String: String].self, from: namesData) {
+            self.sessionNames = names
         }
     }
 
     private func saveColors() {
         if let data = try? JSONEncoder().encode(sessionColors) {
-            defaults.set(data, forKey: colorsKey)
+            self.defaults.set(data, forKey: self.colorsKey)
         }
     }
 
     private func saveNames() {
         if let data = try? JSONEncoder().encode(sessionNames) {
-            defaults.set(data, forKey: namesKey)
+            self.defaults.set(data, forKey: self.namesKey)
         }
     }
 }

--- a/ClaudeIsland/UI/Components/SessionLabelEditor.swift
+++ b/ClaudeIsland/UI/Components/SessionLabelEditor.swift
@@ -8,53 +8,39 @@
 import SwiftUI
 
 struct SessionLabelEditor: View {
-    let sessionID: String
+    // MARK: Internal
 
-    static let colorPresets: [(color: Color, hex: String)] = [
-        (Color(red: 0.94, green: 0.27, blue: 0.27), "EF4444"), // red
-        (Color(red: 0.98, green: 0.45, blue: 0.09), "F97316"), // orange
-        (Color(red: 0.92, green: 0.70, blue: 0.03), "EAB308"), // yellow
-        (Color(red: 0.13, green: 0.77, blue: 0.37), "22C55E"), // green
-        (Color(red: 0.23, green: 0.51, blue: 0.96), "3B82F6"), // blue
-        (Color(red: 0.55, green: 0.36, blue: 0.96), "8B5CF6"), // purple
-        (Color(red: 0.93, green: 0.29, blue: 0.60), "EC4899"), // pink
+    static let colorPresets: [String] = [
+        "EF4444", // red
+        "F97316", // orange
+        "EAB308", // yellow
+        "22C55E", // green
+        "3B82F6", // blue
+        "8B5CF6", // purple
+        "EC4899", // pink
     ]
 
-    private let metadataManager = SessionMetadataManager.shared
+    let sessionID: String
 
     var body: some View {
         HStack(spacing: 8) {
-            ForEach(Array(Self.colorPresets.enumerated()), id: \.offset) { _, preset in
-                colorDot(preset.color, hex: preset.hex)
+            ForEach(Self.colorPresets, id: \.self) { hex in
+                self.colorDot(hex: hex)
             }
 
             Spacer()
 
-            clearButton
+            self.clearButton
         }
     }
 
-    private func colorDot(_ color: Color, hex: String) -> some View {
-        let currentHex = metadataManager.sessionColors[sessionID]
-        let isSelected = currentHex == hex
+    // MARK: Private
 
-        return Button {
-            metadataManager.setColor(hex, for: sessionID)
-        } label: {
-            Circle()
-                .fill(color)
-                .frame(width: 18, height: 18)
-                .overlay(
-                    Circle()
-                        .stroke(Color.white, lineWidth: isSelected ? 2 : 0)
-                )
-        }
-        .buttonStyle(.plain)
-    }
+    private let metadataManager = SessionMetadataManager.shared
 
     private var clearButton: some View {
         Button {
-            metadataManager.setColor(nil, for: sessionID)
+            self.metadataManager.setColor(nil, for: self.sessionID)
         } label: {
             Circle()
                 .stroke(Color.white.opacity(0.3), lineWidth: 1)
@@ -63,6 +49,24 @@ struct SessionLabelEditor: View {
                     Image(systemName: "xmark")
                         .font(.system(size: 9, weight: .medium))
                         .foregroundColor(.white.opacity(0.4))
+                )
+        }
+        .buttonStyle(.plain)
+    }
+
+    private func colorDot(hex: String) -> some View {
+        let currentHex = self.metadataManager.sessionColors[self.sessionID]
+        let isSelected = currentHex == hex
+
+        return Button {
+            self.metadataManager.setColor(hex, for: self.sessionID)
+        } label: {
+            Circle()
+                .fill(Color(hex: hex) ?? .gray)
+                .frame(width: 18, height: 18)
+                .overlay(
+                    Circle()
+                        .stroke(Color.white, lineWidth: isSelected ? 2 : 0)
                 )
         }
         .buttonStyle(.plain)


### PR DESCRIPTION
## Summary
- Simplify `colorPresets` in `SessionLabelEditor` from redundant `(Color, String)` tuples to hex-only `[String]`, using the existing `Color(hex:)` initializer
- Remove dead `clearMetadata(for:)` method from `SessionMetadataManager`
- Restore doc comments removed during #58 refactoring (`spinnerTimer`, `isWaitingForApproval`, `isInteractiveTool`, `phaseStatusText`)
- Fix swiftlint `fatal_error_message` violation in `RightClickNSView`

## Test plan
- [x] Build succeeds with `xcodebuild -scheme ClaudeIsland -configuration Release build`
- [x] All pre-commit hooks pass (swiftformat, swiftlint)
- [ ] Verify color presets still render correctly in the UI