### PR TITLE
Fix CLI OAuth token lookup to match Claude Code keychain format

### DIFF
--- a/ClaudeIsland/Core/TokenTrackingManager.swift
+++ b/ClaudeIsland/Core/TokenTrackingManager.swift
@@ -331,7 +331,12 @@ final class TokenTrackingManager {
         } else if let str = source["expiresAt"] as? String {
             let formatter = ISO8601DateFormatter()
             formatter.formatOptions = [.withInternetDateTime, .withFractionalSeconds]
-            if let expiry = formatter.date(from: str) {
+            var expiry = formatter.date(from: str)
+            if expiry == nil {
+                formatter.formatOptions = [.withInternetDateTime]
+                expiry = formatter.date(from: str)
+            }
+            if let expiry {
                 if expiry < Date() {
                     logger.warning("CLI OAuth token is expired (expiry: \(expiry))")
                     return true


### PR DESCRIPTION
## Summary

- Fix Keychain service/account names to match the format used by Claude Code CLI (`Claude Code-credentials` / `NSUserName()` instead of `claude-cli` / `oauth-tokens`)
- Parse the nested JSON structure (`claudeAiOauth.accessToken`) that Claude Code actually writes, with flat format as fallback
- Handle `expiresAt` as a Unix timestamp in milliseconds (the actual format), with `Int` and ISO8601 string as fallbacks
- Add diagnostic logging throughout the token lookup flow for debuggability
- Extract keychain discovery and expiry checking into separate methods to satisfy `function_body_length` lint rule

These five bugs caused `getCLIOAuthToken()` to silently return `nil`, preventing token usage rings from ever populating with data.

## Test plan

- [ ] Build succeeds with `xcodebuild -scheme ClaudeIsland -configuration Debug build`
- [ ] With CLI OAuth enabled in settings, verify log output via `/usr/bin/log stream --predicate 'subsystem == "com.engels74.ClaudeIsland"' --level debug` shows successful token discovery and usage fetch
- [ ] Token usage rings display non-zero data when a valid Claude Code OAuth session exists
- [ ] Fallback to session key still works when no CLI OAuth token is present