### PR TITLE
Fix persistent keychain prompts by caching CLI OAuth credentials

### DIFF
--- a/ClaudeIsland/Core/TokenTrackingManager.swift
+++ b/ClaudeIsland/Core/TokenTrackingManager.swift
@@ -130,8 +130,12 @@ final class TokenTrackingManager {
             return true
         }
 
-        if updateStatus == errSecItemNotFound {
-            // Item doesn't exist yet, add new
+        // errSecItemNotFound: item doesn't exist yet
+        // errSecParam: existing item may have incompatible attributes (e.g. different kSecAttrAccessible)
+        if updateStatus == errSecItemNotFound || updateStatus == errSecParam {
+            if updateStatus == errSecParam {
+                SecItemDelete(baseQuery as CFDictionary)
+            }
             var addQuery = baseQuery
             addQuery[kSecValueData as String] = valueData
             addQuery[kSecAttrAccessible as String] = kSecAttrAccessibleWhenUnlockedThisDeviceOnly
@@ -227,8 +231,13 @@ final class TokenTrackingManager {
                     self.updateFromAPIResponse(response)
                     return
                 } catch {
-                    // Cached token may be stale — invalidate so next attempt re-reads from CLI keychain
-                    self.deleteCLIOAuthCache()
+                    // Only invalidate cache for authentication rejections — transient errors
+                    // should not wipe a valid token and re-trigger keychain prompts
+                    if let apiError = error as? APIServiceError,
+                       case let .httpError(statusCode) = apiError,
+                       statusCode == 401 || statusCode == 403 {
+                        self.deleteCLIOAuthCache()
+                    }
                     throw TokenTrackingError.apiError(error.errorDescription ?? "API request failed")
                 }
             } else {
@@ -294,7 +303,12 @@ extension TokenTrackingManager {
             return true
         }
 
-        if updateStatus == errSecItemNotFound {
+        // errSecItemNotFound: item doesn't exist yet
+        // errSecParam: existing item may have incompatible attributes (e.g. different kSecAttrAccessible)
+        if updateStatus == errSecItemNotFound || updateStatus == errSecParam {
+            if updateStatus == errSecParam {
+                SecItemDelete(baseQuery as CFDictionary)
+            }
             var addQuery = baseQuery
             addQuery[kSecValueData as String] = data
             addQuery[kSecAttrAccessible as String] = kSecAttrAccessibleWhenUnlockedThisDeviceOnly


### PR DESCRIPTION
## Summary

- Cache the CLI's OAuth token data in Claude Island's own keychain entry (`com.engels74.ClaudeIsland / cli-oauth-cache`) after a successful read, so subsequent lookups never trigger a macOS keychain prompt
- Add a 5-minute cooldown on CLI keychain access attempts to prevent repeated prompts when the user denies access
- Invalidate the cache when the API rejects a cached token, forcing a fresh read from the CLI keychain on the next attempt
- Set `kSecAttrAccessibleWhenUnlockedThisDeviceOnly` on all keychain items for improved security

## Context

The Claude CLI's keychain item ACL resets on every token refresh, removing Claude Island's "Always Allow" entry. Because Claude Island is ad-hoc signed (no stable app identity), macOS treats each access as a new request, prompting the user every time the app restarts or the CLI refreshes its token. This fix eliminates the persistent prompts by reading the CLI keychain once and caching the result under Claude Island's own service identity.

## Test plan

- [ ] Launch Claude Island and verify the initial CLI keychain prompt appears once
- [ ] Confirm subsequent token refreshes use the cached credential without prompting
- [ ] Deny the initial keychain prompt and verify no repeated prompts occur within 5 minutes
- [ ] Revoke the OAuth token server-side and confirm the cache is invalidated on the next API call, triggering a fresh keychain read