### PR TITLE
Fix pipefail crash in build.sh check_version_sync

### DIFF
--- a/scripts/build.sh
+++ b/scripts/build.sh
@@ -9,9 +9,10 @@ EXPORT_PATH="$BUILD_DIR/export"
 
 # Check if local version matches latest git tag
 check_version_sync() {
-    LATEST_TAG=$(cd "$PROJECT_DIR" && git describe --tags --abbrev=0 2>/dev/null | sed 's/^v//')
+    LATEST_TAG=$(git -C "$PROJECT_DIR" describe --tags --abbrev=0 2>/dev/null || true)
+    LATEST_TAG="${LATEST_TAG#v}"
     if [ -n "$LATEST_TAG" ]; then
-        CURRENT_VERSION=$(cd "$PROJECT_DIR" && agvtool what-marketing-version -terse1 2>/dev/null)
+        CURRENT_VERSION=$(cd "$PROJECT_DIR" && agvtool what-marketing-version -terse1 2>/dev/null) || true
         if [ -n "$CURRENT_VERSION" ] && [ "$LATEST_TAG" != "$CURRENT_VERSION" ]; then
             echo "⚠️  Warning: Local version ($CURRENT_VERSION) differs from latest tag ($LATEST_TAG)"
             echo "   Run: agvtool new-marketing-version $LATEST_TAG"


### PR DESCRIPTION
## Summary

- Fixes CI build failure introduced by PR #78, which added `set -eo pipefail` to `scripts/build.sh`
- The `check_version_sync()` function piped `git describe --tags` through `sed`, which crashes with exit code 128 in shallow clones (no tags available) when `pipefail` is enabled
- Resolves failed CI run [#22529196858](https://github.com/engels74/claude-island/actions/runs/22529196858)

## Changes

- Added `|| true` after `git describe` to suppress non-zero exit under `pipefail`
- Replaced `| sed 's/^v//'` pipe with bash parameter expansion `${LATEST_TAG#v}`
- Added `|| true` for `agvtool` call for defensive consistency
- Used `git -C` instead of subshell `cd` (shellcheck-preferred pattern)

## Test plan

- [x] Verified in shallow clone simulation (no tags) -- `check_version_sync()` no longer crashes
- [x] Verified with tags present -- version mismatch warning still works correctly
- [x] `shellcheck scripts/build.sh` passes clean
- [x] `prek run --all-files` passes (one pre-existing swiftlint issue from PR #78, unrelated)