### PR TITLE
fix: add notch auto-expand preference (default off)

### DIFF
--- a/ClaudeIsland/Core/Settings.swift
+++ b/ClaudeIsland/Core/Settings.swift
@@ -168,6 +168,14 @@ enum AppSettings {
         set { defaults.set(newValue, forKey: Keys.clawdAlwaysVisible) }
     }
 
+    // MARK: - Notch Auto-Expand
+
+    /// Whether the notch should auto-expand when new pending sessions arrive
+    static var notchAutoExpand: Bool {
+        get { defaults.bool(forKey: Keys.notchAutoExpand) }
+        set { defaults.set(newValue, forKey: Keys.notchAutoExpand) }
+    }
+
     // MARK: - Token Tracking Mode
 
     static var tokenTrackingMode: TokenTrackingMode {
@@ -245,6 +253,7 @@ enum AppSettings {
         static let soundSuppression = "soundSuppression"
         static let clawdColor = "clawdColor"
         static let clawdAlwaysVisible = "clawdAlwaysVisible"
+        static let notchAutoExpand = "notchAutoExpand"
         static let tokenTrackingMode = "tokenTrackingMode"
         static let tokenUseCLIOAuth = "tokenUseCliOAuth"
         static let tokenShowRingsMinimized = "tokenShowRingsMinimized"

--- a/ClaudeIsland/UI/Views/NotchMenuView.swift
+++ b/ClaudeIsland/UI/Views/NotchMenuView.swift
@@ -57,6 +57,14 @@ struct NotchMenuView: View {
                         SuppressionPickerRow(suppressionSelector: self.suppressionSelector)
                         ClawdPickerRow(clawdSelector: self.clawdSelector)
 
+                        MenuToggleRow(
+                            icon: "arrow.up.left.and.arrow.down.right",
+                            label: "Notch Auto-Expand",
+                            isOn: self.notchAutoExpand,
+                        ) {
+                            self.notchAutoExpand.toggle()
+                        }
+
                         MenuRow(
                             icon: "rectangle.split.3x1",
                             label: "Notch Layout",
@@ -193,6 +201,9 @@ struct NotchMenuView: View {
     @State private var hookInstallTask: Task<Void, Never>?
     @State private var showWhatsNew = false
     @State private var showLayoutSettings = false
+    // swiftformat:disable:next wrapAttributes
+    @AppStorage("notchAutoExpand")
+    private var notchAutoExpand = false
     // swiftformat:disable:next wrapAttributes
     @AppStorage("verboseMode")
     private var verboseMode = false

--- a/ClaudeIsland/UI/Views/NotchView.swift
+++ b/ClaudeIsland/UI/Views/NotchView.swift
@@ -544,6 +544,7 @@ struct NotchView: View {
         let newPendingIDs = currentIDs.subtracting(self.previousPendingIDs)
 
         if !newPendingIDs.isEmpty &&
+            AppSettings.notchAutoExpand &&
             self.viewModel.status == .closed &&
             !TerminalVisibilityDetector.isTerminalVisibleOnCurrentSpace() {
             self.viewModel.notchOpen(reason: .notification)


### PR DESCRIPTION
## Summary
- Adds a "Notch Auto-Expand" toggle to the settings menu (default: **off**)
- When off, the notch stays minimized when sessions need attention (permission requests, waiting for input) — bounce animation and notification sounds still fire
- When on, preserves the original behavior (auto-expand when terminal is not visible)

### Files changed
| File | Change |
|------|--------|
| `Settings.swift` | Added `notchAutoExpand` Bool property (default `false`) + UserDefaults key |
| `NotchMenuView.swift` | Added "Notch Auto-Expand" `MenuToggleRow` with `@AppStorage` binding |
| `NotchView.swift` | Gated `notchOpen(reason: .notification)` behind `AppSettings.notchAutoExpand` |

## Test plan
- [ ] Build succeeds (`xcodebuild -scheme ClaudeIsland -configuration Release build`)
- [ ] Lint passes (`swiftformat . && swiftlint lint --strict`)
- [ ] Toggle appears in settings menu between Clawd color picker and Notch Layout
- [ ] Default is Off — notch does not auto-expand on new pending sessions
- [ ] When toggled On — notch auto-expands when terminal is not visible and a session needs attention
- [ ] Click-to-expand, hover-to-expand, boot animation, bounce, and notification sounds all unchanged