### PR TITLE
fix: output empty JSON on all hook exit paths to prevent parallel hook interference

### DIFF
--- a/ClaudeIsland/Resources/claude-island-state.py
+++ b/ClaudeIsland/Resources/claude-island-state.py
@@ -457,6 +457,7 @@ def handle_permission_response(response: PermissionResponse | None, /) -> None:
     """
     if not response:
         # No response or "ask" - let Claude Code show its normal UI
+        print("{}")
         return
 
     decision = response.get("decision", "ask")


### PR DESCRIPTION
## Summary

- When `claude-island-state.py` runs alongside another PreToolUse hook (e.g., RTK's `rtk-rewrite.sh`), Claude Code runs both hooks in parallel and merges their stdout results. The hook's fire-and-forget events previously produced no stdout, which caused the merger to discard the other hook's `updatedInput` payload.
- All non-permission exit paths now output `{}` (empty JSON) to stdout, giving Claude Code a valid "no modifications" signal that merges cleanly with other hooks' output.

## Changes

Three exit paths in `claude-island-state.py` are updated:

1. **`handle_permission_response` fall-through** -- outputs `{}` instead of `pass` when the decision is "ask" or unknown.
2. **"skip" early exit** -- outputs `{}` before `sys.exit(0)` for skipped events (e.g., duplicate `permission_prompt` notifications).
3. **End of `main()`** -- outputs `{}` after the fire-and-forget socket send for all standard events (PreToolUse, PostToolUse, Stop, etc.).

## Test plan

- [ ] Build and launch ClaudeIsland to install the updated hook script
- [ ] Verify `~/.claude/settings.json` has both `rtk-rewrite.sh` and `claude-island-state.py` on PreToolUse
- [ ] Run `claude --debug`, trigger a git command, and confirm RTK's rewrite is applied (check `rtk gain --history`)
- [ ] Verify ClaudeIsland notch still shows `running_tool` status during tool execution
- [ ] Confirm permission approval/denial flow is unaffected