### PR TITLE
fix: resolve clamshell mode breaking notch UI and session detection

### DIFF
--- a/ClaudeIsland/App/AppDelegate.swift
+++ b/ClaudeIsland/App/AppDelegate.swift
@@ -107,6 +107,20 @@ class AppDelegate: NSObject, NSApplicationDelegate {
     private let userDriver: NotchUserDriver
 
     private func handleScreenChange() {
+        let screens = NSScreen.screens
+        Self.logger.info("Screen config changed: \(screens.count, privacy: .public) screen(s)")
+        for (index, screen) in screens.enumerated() {
+            let id = screen.deviceDescription[
+                NSDeviceDescriptionKey("NSScreenNumber"),
+            ] as? CGDirectDisplayID ?? 0
+            let name = screen.localizedName
+            let frame = screen.frame
+            let builtin = screen.isBuiltinDisplay
+            let notch = screen.hasPhysicalNotch
+            Self.logger.info(
+                "  [\(index, privacy: .public)] \(name, privacy: .public) id=\(id, privacy: .public) frame=\(frame.debugDescription, privacy: .public) builtin=\(builtin, privacy: .public) notch=\(notch, privacy: .public)",
+            )
+        }
         _ = self.windowManager?.setupNotchWindow()
     }
 

--- a/ClaudeIsland/App/WindowManager.swift
+++ b/ClaudeIsland/App/WindowManager.swift
@@ -28,15 +28,26 @@ final class WindowManager {
             return nil
         }
 
-        // Skip recreation if screen hasn't meaningfully changed (same frame AND same display)
         let screenDisplayID = self.displayID(of: screen)
+        let logID = screenDisplayID ?? 0
+        let name = screen.localizedName
+        let frame = screen.frame
+        Self.logger.info(
+            "Selected screen: \(name, privacy: .public) id=\(logID, privacy: .public) frame=\(frame.debugDescription, privacy: .public)",
+        )
+
+        // Skip recreation if screen hasn't meaningfully changed (same frame AND same display)
         if let existingController = windowController,
            let existingFrame = currentScreenFrame,
            existingFrame == screen.frame,
-           currentDisplayID == screenDisplayID {
+           let existingDisplayID = currentDisplayID,
+           let newDisplayID = screenDisplayID,
+           existingDisplayID == newDisplayID {
             Self.logger.debug("Screen unchanged, skipping window recreation")
             return existingController
         }
+
+        Self.logger.info("Recreating notch window for display \(logID, privacy: .public)")
 
         // Only animate on initial app launch, not on screen changes
         let shouldAnimate = self.isInitialLaunch

--- a/ClaudeIsland/Core/NSScreen+Notch.swift
+++ b/ClaudeIsland/Core/NSScreen+Notch.swift
@@ -52,10 +52,7 @@ extension NSScreen {
 
     /// The built-in display (with notch on newer MacBooks)
     static var builtin: NSScreen? {
-        if let builtin = screens.first(where: { $0.isBuiltinDisplay }) {
-            return builtin
-        }
-        return NSScreen.main
+        screens.first { $0.isBuiltinDisplay }
     }
 
     /// Whether this screen has a physical notch (camera housing)

--- a/ClaudeIsland/Core/NotchViewModel.swift
+++ b/ClaudeIsland/Core/NotchViewModel.swift
@@ -374,7 +374,7 @@ final class NotchViewModel {
             guard !Task.isCancelled else { return }
 
             // Convert to CGEvent coordinate system (screen coordinates with Y from top-left)
-            guard let screen = NSScreen.main else { return }
+            guard let screen = NSScreen.screens.first else { return }
             let screenHeight = screen.frame.height
             let cgPoint = CGPoint(x: location.x, y: screenHeight - location.y)
 

--- a/ClaudeIsland/Services/Hooks/HookSocketServer.swift
+++ b/ClaudeIsland/Services/Hooks/HookSocketServer.swift
@@ -266,6 +266,15 @@ final class HookSocketServer: @unchecked Sendable { // swiftlint:disable:this ty
         }
     }
 
+    /// Update event handlers without restarting the server.
+    /// Called after window recreation so new ClaudeSessionMonitor closures replace stale ones.
+    nonisolated func updateEventHandler(onEvent: @escaping HookEventHandler, onPermissionFailure: PermissionFailureHandler? = nil) {
+        queue.async { [weak self] in
+            self?.eventHandler = onEvent
+            self?.permissionFailureHandler = onPermissionFailure
+        }
+    }
+
     /// Stop the socket server
     nonisolated func stop() {
         // All state mutations must happen on the queue to avoid races

--- a/ClaudeIsland/Services/Session/ClaudeSessionMonitor.swift
+++ b/ClaudeIsland/Services/Session/ClaudeSessionMonitor.swift
@@ -43,20 +43,24 @@ final class ClaudeSessionMonitor {
     // MARK: - Monitoring Lifecycle
 
     func startMonitoring() {
-        HookSocketServer.shared.start(
-            onEvent: { [weak self] event in
-                // HookSocketServer calls this callback on its internal socket queue.
-                // Single MainActor hop handles all event processing.
-                Task(name: "hook-event") { @MainActor [weak self] in
-                    await self?.handleHookEvent(event)
-                }
-            },
-            onPermissionFailure: { [weak self] sessionID, toolUseID in
-                Task(name: "permission-failure") { @MainActor [weak self] in
-                    await self?.handlePermissionFailure(sessionID: sessionID, toolUseID: toolUseID)
-                }
-            },
-        )
+        let onEvent: HookEventHandler = { [weak self] event in
+            // HookSocketServer calls this callback on its internal socket queue.
+            // Single MainActor hop handles all event processing.
+            Task(name: "hook-event") { @MainActor [weak self] in
+                await self?.handleHookEvent(event)
+            }
+        }
+
+        let onPermissionFailure: PermissionFailureHandler = { [weak self] sessionID, toolUseID in
+            Task(name: "permission-failure") { @MainActor [weak self] in
+                await self?.handlePermissionFailure(sessionID: sessionID, toolUseID: toolUseID)
+            }
+        }
+
+        HookSocketServer.shared.start(onEvent: onEvent, onPermissionFailure: onPermissionFailure)
+        // After window recreation, the server is already running so start() is a no-op.
+        // Always update handlers so this monitor's closures replace any stale ones.
+        HookSocketServer.shared.updateEventHandler(onEvent: onEvent, onPermissionFailure: onPermissionFailure)
 
         // Start periodic session status check
         Task(name: "start-periodic-check") {

--- a/ClaudeIsland/UI/Window/NotchWindow.swift
+++ b/ClaudeIsland/UI/Window/NotchWindow.swift
@@ -105,7 +105,7 @@ class NotchPanel: NSPanel {
 
     private func repostMouseEvent(_ event: NSEvent, at screenLocation: NSPoint) {
         // Convert to CGEvent coordinate system (Y from top of screen)
-        guard let screen = NSScreen.main else { return }
+        guard let screen = NSScreen.screens.first else { return }
         let screenHeight = screen.frame.height
         let cgPoint = CGPoint(x: screenLocation.x, y: screenHeight - screenLocation.y)
 


### PR DESCRIPTION
## Summary

Fixes #88. When entering clamshell mode (closing laptop lid with an external monitor), Claude Island became unclickable and stopped detecting running Claude sessions.

**Root cause:** Window recreation during display transitions destroyed the old `ClaudeSessionMonitor`, but `HookSocketServer` retained stale event handler closures. The server's early-return guard in `startServer()` prevented callback updates on subsequent `start()` calls, so all hook events were silently dropped (the `[weak self]` captures resolved to nil).

**Fixes (5 bugs):**

- **Stale event handler (critical):** Added `HookSocketServer.updateEventHandler()` to refresh callbacks without restarting the server. `ClaudeSessionMonitor.startMonitoring()` now calls this after `start()` so window recreation always installs fresh closures.
- **NSScreen.builtin fallback:** Removed the misleading `NSScreen.main` fallback from `NSScreen.builtin` so it correctly returns `nil` in clamshell mode. All callers already handle `nil` via `?? NSScreen.main`.
- **CGEvent coordinate conversion:** Changed `NSScreen.main` to `NSScreen.screens.first` in `NotchWindow` and `NotchViewModel` click-reposting. CGEvent coordinates are relative to the primary display, not the focused window's screen.
- **nil display ID comparison:** Added `let` bindings in `WindowManager.setupNotchWindow()` to prevent `nil == nil` from incorrectly skipping window recreation during rapid display transitions.
- **Diagnostic logging:** Added screen configuration change logging to `AppDelegate` and `WindowManager` for remote debugging via Console.app.

## Files changed

| File | Change |
|------|--------|
| `HookSocketServer.swift` | Added `updateEventHandler()` method |
| `ClaudeSessionMonitor.swift` | Extracted closures, calls `updateEventHandler()` after `start()` |
| `Ext+NSScreen.swift` | Removed `NSScreen.main` fallback from `builtin` |
| `NotchViewModel.swift` | `NSScreen.main` -> `NSScreen.screens.first` |
| `NotchWindow.swift` | `NSScreen.main` -> `NSScreen.screens.first` |
| `WindowManager.swift` | nil display ID guard, diagnostic logging |
| `AppDelegate.swift` | Screen change diagnostic logging |

## Test plan

- [ ] Build succeeds: `xcodebuild -scheme ClaudeIsland -configuration Release build`
- [ ] Lint passes: `swiftformat . && swiftlint lint --strict`
- [ ] Manual test (built-in display): Launch app, verify notch appears, sessions detected, hover/click work
- [ ] Manual test (clamshell mode): Launch with active Claude session, connect external monitor, close lid -- verify notch UI appears on external monitor and sessions remain detected
- [ ] Manual test (return from clamshell): Open lid, verify notch returns to built-in display
- [ ] Console.app: Filter `com.engels74.ClaudeIsland` during display transitions, verify screen change logs appear