### PR TITLE
Part 1 - feat: dual-mode chat view redesign

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -45,3 +45,5 @@ releases/
 .claude/settings.local.json
 
 docs/plans/
+
+.superpowers/

--- a/.swiftformat
+++ b/.swiftformat
@@ -83,5 +83,4 @@
 
 # Rules to disable (overly aggressive or conflict with project style)
 --disable andOperator
---disable redundantSendable
 --disable wrapMultilineStatementBraces

--- a/ClaudeIsland/Core/NotchGeometry.swift
+++ b/ClaudeIsland/Core/NotchGeometry.swift
@@ -38,7 +38,7 @@ struct NotchGeometry: Sendable {
     }
 
     /// Check if a point is in the notch area (with padding for easier interaction)
-    @inline(always)
+    @inline(__always)
     func isPointInNotch(_ point: CGPoint) -> Bool {
         self.notchScreenRect.insetBy(dx: -10, dy: -5).contains(point)
     }
@@ -49,7 +49,7 @@ struct NotchGeometry: Sendable {
     }
 
     /// Check if a point is outside the opened panel (for closing)
-    @inline(always)
+    @inline(__always)
     func isPointOutsidePanel(_ point: CGPoint, size: CGSize) -> Bool {
         !self.openedScreenRect(for: size).contains(point)
     }

--- a/ClaudeIsland/Core/NotchViewModel.swift
+++ b/ClaudeIsland/Core/NotchViewModel.swift
@@ -72,6 +72,7 @@ final class NotchViewModel {
     var openReason: NotchOpenReason = .unknown
     var contentType: NotchContentType = .instances
     var isHovering = false
+    var chatPanelWidthFraction: Double = AppSettings.chatPanelWidthFraction
 
     // MARK: - Geometry
 
@@ -116,7 +117,7 @@ final class NotchViewModel {
         case .chat:
             // Large size for chat view
             return CGSize(
-                width: min(self.screenRect.width * 0.5, 600),
+                width: min(self.screenRect.width * self.chatPanelWidthFraction, self.screenRect.width * 0.8),
                 height: 580,
             )
         case .menu:

--- a/ClaudeIsland/Core/Settings.swift
+++ b/ClaudeIsland/Core/Settings.swift
@@ -106,6 +106,13 @@ enum NotificationSound: String, CaseIterable {
     }
 }
 
+// MARK: - ChatViewMode
+
+enum ChatViewMode: String, CaseIterable {
+    case terminal = "Terminal"
+    case chat = "Chat"
+}
+
 // MARK: - AppSettings
 
 enum AppSettings {
@@ -244,6 +251,32 @@ enum AppSettings {
         set { defaults.set(newValue, forKey: Keys.verboseMode) }
     }
 
+    // MARK: - Chat Panel Width
+
+    static var chatPanelWidthFraction: Double {
+        get {
+            let value = defaults.double(forKey: Keys.chatPanelWidthFraction)
+            return value > 0 ? value : 0.5
+        }
+        set { defaults.set(newValue, forKey: Keys.chatPanelWidthFraction) }
+    }
+
+    // MARK: - Chat View Mode
+
+    static var chatViewMode: ChatViewMode {
+        get {
+            guard let rawValue = defaults.string(forKey: Keys.chatViewMode),
+                  let mode = ChatViewMode(rawValue: rawValue)
+            else {
+                return .terminal
+            }
+            return mode
+        }
+        set {
+            defaults.set(newValue.rawValue, forKey: Keys.chatViewMode)
+        }
+    }
+
     // MARK: Private
 
     // MARK: - Keys
@@ -261,6 +294,8 @@ enum AppSettings {
         static let tokenShowResetTime = "tokenShowResetTime"
         static let moduleLayoutConfig = "moduleLayoutConfig"
         static let verboseMode = "verboseMode"
+        static let chatPanelWidthFraction = "chatPanelWidthFraction"
+        static let chatViewMode = "chatViewMode"
     }
 
     private static let defaults = UserDefaults.standard

--- a/ClaudeIsland/Models/SessionPhase.swift
+++ b/ClaudeIsland/Models/SessionPhase.swift
@@ -97,7 +97,7 @@ nonisolated enum SessionPhase: Sendable {
     // swiftlint:disable attributes
 
     /// Whether this phase indicates the session needs user attention
-    @inline(always) var needsAttention: Bool {
+    @inline(__always) var needsAttention: Bool {
         switch self {
         case .waitingForApproval,
              .waitingForInput:
@@ -108,7 +108,7 @@ nonisolated enum SessionPhase: Sendable {
     }
 
     /// Whether this phase indicates active processing
-    @inline(always) var isActive: Bool {
+    @inline(__always) var isActive: Bool {
         switch self {
         case .processing,
              .compacting:
@@ -119,7 +119,7 @@ nonisolated enum SessionPhase: Sendable {
     }
 
     /// Whether this is a waitingForApproval phase
-    @inline(always) nonisolated var isWaitingForApproval: Bool {
+    @inline(__always) nonisolated var isWaitingForApproval: Bool {
         if case .waitingForApproval = self {
             return true
         }

--- a/ClaudeIsland/Services/Session/ConversationParser.swift
+++ b/ClaudeIsland/Services/Session/ConversationParser.swift
@@ -329,15 +329,16 @@ actor ConversationParser {
         return input.values.compactMap { $0 as? String }.first { !$0.isEmpty } ?? ""
     }
 
-    /// Truncate message for display
+    private static let systemPrefixes = ["<command-name>", "<command-message>", "<command-args>", "<local-command", "Caveat:"]
+
+    private static func isSystemMessage(_ content: String) -> Bool {
+        self.systemPrefixes.contains { content.hasPrefix($0) }
+    }
+
     private static func truncateMessage(_ message: String?, maxLength: Int = 80) -> String? {
         guard let msg = message else { return nil }
-        let cleaned = msg.trimmingCharacters(in: .whitespacesAndNewlines)
-            .replacingOccurrences(of: "\n", with: " ")
-        if cleaned.count > maxLength {
-            return String(cleaned.prefix(maxLength - 3)) + "..."
-        }
-        return cleaned
+        let cleaned = msg.trimmingCharacters(in: .whitespacesAndNewlines).replacingOccurrences(of: "\n", with: " ")
+        return cleaned.count > maxLength ? String(cleaned.prefix(maxLength - 3)) + "..." : cleaned
     }
 
     /// Build session file path
@@ -507,7 +508,7 @@ actor ConversationParser {
             if type == "user" && !isMeta {
                 if let message = json["message"] as? [String: Any],
                    let msgContent = message["content"] as? String {
-                    if !msgContent.hasPrefix("<command-name>") && !msgContent.hasPrefix("<local-command") && !msgContent.hasPrefix("Caveat:") {
+                    if !Self.isSystemMessage(msgContent) {
                         firstUserMessage = Self.truncateMessage(msgContent, maxLength: 50)
                         break
                     }
@@ -530,8 +531,7 @@ actor ConversationParser {
                     let isMeta = json["isMeta"] as? Bool ?? false
                     if !isMeta, let message = json["message"] as? [String: Any] {
                         if let msgContent = message["content"] as? String {
-                            if !msgContent.hasPrefix("<command-name>") && !msgContent.hasPrefix("<local-command") && !msgContent
-                                .hasPrefix("Caveat:") {
+                            if !Self.isSystemMessage(msgContent) {
                                 lastMessage = msgContent
                                 lastMessageRole = type
                             }
@@ -562,7 +562,7 @@ actor ConversationParser {
                 let isMeta = json["isMeta"] as? Bool ?? false
                 if !isMeta, let message = json["message"] as? [String: Any] {
                     if let msgContent = message["content"] as? String {
-                        if !msgContent.hasPrefix("<command-name>") && !msgContent.hasPrefix("<local-command") && !msgContent.hasPrefix("Caveat:") {
+                        if !Self.isSystemMessage(msgContent) {
                             if let timestampStr = json["timestamp"] as? String {
                                 lastUserMessageDate = formatter.date(from: timestampStr)
                             }
@@ -719,7 +719,7 @@ actor ConversationParser {
         blocks.reserveCapacity(4) // Most messages have 2-4 blocks
 
         if let content = messageDict["content"] as? String {
-            if content.hasPrefix("<command-name>") || content.hasPrefix("<local-command") || content.hasPrefix("Caveat:") {
+            if Self.isSystemMessage(content) {
                 return nil
             }
             if content.hasPrefix("[Request interrupted by user") {

--- a/ClaudeIsland/Services/Shared/ProcessExecutor.swift
+++ b/ClaudeIsland/Services/Shared/ProcessExecutor.swift
@@ -109,10 +109,13 @@ nonisolated struct ProcessExecutor: ProcessExecuting, Sendable {
             let stderr = result.standardError
 
             // Extract exit code from TerminationStatus
+            // For signals, use Unix convention: 128 + signal number (e.g., SIGTERM=15 -> 143, SIGKILL=9 -> 137)
             let exitCode: Int32 = if result.terminationStatus.isSuccess {
                 0
             } else if case let .exited(code) = result.terminationStatus {
                 code
+            } else if case let .signaled(signal) = result.terminationStatus {
+                128 + signal
             } else {
                 1
             }

--- a/ClaudeIsland/Services/Shared/ProcessExecutor.swift
+++ b/ClaudeIsland/Services/Shared/ProcessExecutor.swift
@@ -108,11 +108,13 @@ nonisolated struct ProcessExecutor: ProcessExecuting, Sendable {
             let stdout = result.standardOutput ?? ""
             let stderr = result.standardError
 
-            // Extract exit code from TerminationStatus enum
-            // For signals, use Unix convention: 128 + signal number (e.g., SIGTERM=15 → 143, SIGKILL=9 → 137)
-            let exitCode: Int32 = switch result.terminationStatus {
-            case let .exited(code): code
-            case let .signaled(signal): 128 + signal
+            // Extract exit code from TerminationStatus
+            let exitCode: Int32 = if result.terminationStatus.isSuccess {
+                0
+            } else if case let .exited(code) = result.terminationStatus {
+                code
+            } else {
+                1
             }
 
             let processResult = ProcessResult(

--- a/ClaudeIsland/UI/Components/CollapsibleContentView.swift
+++ b/ClaudeIsland/UI/Components/CollapsibleContentView.swift
@@ -7,6 +7,8 @@
 
 import SwiftUI
 
+// MARK: - CollapsibleContentView
+
 struct CollapsibleContentView<Content: View>: View {
     // MARK: Lifecycle
 
@@ -27,7 +29,7 @@ struct CollapsibleContentView<Content: View>: View {
     // MARK: Internal
 
     var body: some View {
-        if self.isExpanded || (self.measuredHeight > 0 && self.measuredHeight <= self.maxHeight) {
+        if self.isExpanded || self.measuredHeight.map({ $0 <= self.maxHeight }) ?? true {
             self.content
                 .background(
                     GeometryReader { proxy in
@@ -84,7 +86,7 @@ struct CollapsibleContentView<Content: View>: View {
     // MARK: Private
 
     @State private var isExpanded = false
-    @State private var measuredHeight: CGFloat = 0
+    @State private var measuredHeight: CGFloat?
 
     private let lineCount: Int?
     private let expandLabel: String?

--- a/ClaudeIsland/UI/Components/CollapsibleContentView.swift
+++ b/ClaudeIsland/UI/Components/CollapsibleContentView.swift
@@ -1,0 +1,114 @@
+//
+//  CollapsibleContentView.swift
+//  ClaudeIsland
+//
+//  Height-capped content with gradient fade and expand link
+//
+
+import SwiftUI
+
+struct CollapsibleContentView<Content: View>: View {
+    // MARK: Lifecycle
+
+    init(
+        lineCount: Int? = nil,
+        expandLabel: String? = nil,
+        backgroundColor: Color = Color(red: 0.086, green: 0.106, blue: 0.133),
+        maxHeight: CGFloat = 120,
+        @ViewBuilder content: () -> Content,
+    ) {
+        self.lineCount = lineCount
+        self.expandLabel = expandLabel
+        self.backgroundColor = backgroundColor
+        self.maxHeight = maxHeight
+        self.content = content()
+    }
+
+    // MARK: Internal
+
+    var body: some View {
+        if self.isExpanded || (self.measuredHeight > 0 && self.measuredHeight <= self.maxHeight) {
+            self.content
+                .background(
+                    GeometryReader { proxy in
+                        Color.clear.preference(key: ContentHeightKey.self, value: proxy.size.height)
+                    },
+                )
+                .onPreferenceChange(ContentHeightKey.self) { value in
+                    self.measuredHeight = value
+                }
+        } else {
+            ZStack(alignment: .bottom) {
+                self.content
+                    .background(
+                        GeometryReader { proxy in
+                            Color.clear.preference(key: ContentHeightKey.self, value: proxy.size.height)
+                        },
+                    )
+                    .onPreferenceChange(ContentHeightKey.self) { value in
+                        self.measuredHeight = value
+                    }
+                    .frame(maxHeight: self.maxHeight, alignment: .top)
+                    .clipped()
+
+                LinearGradient(
+                    colors: [self.backgroundColor.opacity(0), self.backgroundColor],
+                    startPoint: .top,
+                    endPoint: .bottom,
+                )
+                .frame(height: 40)
+
+                Button {
+                    withAnimation(.spring(response: 0.25, dampingFraction: 0.8)) {
+                        self.isExpanded = true
+                    }
+                } label: {
+                    Text(self.resolvedLabel)
+                        .font(.system(size: 9, design: .monospaced))
+                        .foregroundColor(Color(red: 0.345, green: 0.651, blue: 1.0))
+                        .padding(.horizontal, 8)
+                        .padding(.vertical, 2)
+                        .background(self.backgroundColor)
+                        .cornerRadius(3)
+                        .overlay(
+                            RoundedRectangle(cornerRadius: 3)
+                                .stroke(Color(red: 0.345, green: 0.651, blue: 1.0).opacity(0.2), lineWidth: 1),
+                        )
+                }
+                .buttonStyle(.plain)
+                .padding(.bottom, 4)
+            }
+        }
+    }
+
+    // MARK: Private
+
+    @State private var isExpanded = false
+    @State private var measuredHeight: CGFloat = 0
+
+    private let lineCount: Int?
+    private let expandLabel: String?
+    private let backgroundColor: Color
+    private let maxHeight: CGFloat
+    private let content: Content
+
+    private var resolvedLabel: String {
+        if let expandLabel {
+            return expandLabel
+        }
+        if let lineCount {
+            return "Show all \(lineCount) lines"
+        }
+        return "Show full output"
+    }
+}
+
+// MARK: - ContentHeightKey
+
+private struct ContentHeightKey: PreferenceKey {
+    static let defaultValue: CGFloat = 0
+
+    static func reduce(value: inout CGFloat, nextValue: () -> CGFloat) {
+        value = max(value, nextValue())
+    }
+}

--- a/ClaudeIsland/UI/Components/MarkdownRenderer.swift
+++ b/ClaudeIsland/UI/Components/MarkdownRenderer.swift
@@ -320,39 +320,41 @@ private struct InlineRenderer: View {
 
     private func renderInline(_ inline: InlineMarkup) -> SwiftUI.Text {
         if let text = inline as? Markdown.Text {
-            return SwiftUI.Text(text.string)
+            SwiftUI.Text(text.string)
                 .font(self.bodyFont)
                 .foregroundColor(self.baseColor)
         } else if let strong = inline as? Strong {
-            return SwiftUI.Text(strong.plainText)
+            SwiftUI.Text(strong.plainText)
                 .font(self.bodyFont)
                 .fontWeight(.bold)
                 .foregroundColor(self.baseColor)
         } else if let emphasis = inline as? Emphasis {
-            return SwiftUI.Text(emphasis.plainText)
+            SwiftUI.Text(emphasis.plainText)
                 .font(self.bodyFont)
                 .italic()
                 .foregroundColor(self.baseColor)
         } else if let code = inline as? InlineCode {
-            return SwiftUI.Text(code.code)
+            SwiftUI.Text(code.code)
                 .font(.system(size: self.fontSize, design: .monospaced))
                 .foregroundColor(self.baseColor)
         } else if let link = inline as? Markdown.Link {
-            return SwiftUI.Text(link.plainText)
+            SwiftUI.Text(link.plainText)
                 .font(self.bodyFont)
                 .foregroundColor(Color.blue)
                 .underline()
         } else if let strike = inline as? Strikethrough {
-            return SwiftUI.Text(strike.plainText)
+            SwiftUI.Text(strike.plainText)
                 .font(self.bodyFont)
                 .strikethrough()
                 .foregroundColor(self.baseColor)
         } else if inline is SoftBreak {
-            return SwiftUI.Text(" ")
+            SwiftUI.Text(" ")
+                .font(self.bodyFont)
         } else if inline is LineBreak {
-            return SwiftUI.Text("\n")
+            SwiftUI.Text("\n")
+                .font(self.bodyFont)
         } else {
-            return SwiftUI.Text(inline.plainText)
+            SwiftUI.Text(inline.plainText)
                 .font(self.bodyFont)
                 .foregroundColor(self.baseColor)
         }

--- a/ClaudeIsland/UI/Components/MarkdownRenderer.swift
+++ b/ClaudeIsland/UI/Components/MarkdownRenderer.swift
@@ -43,10 +43,11 @@ private final class DocumentCache: Sendable {
 struct MarkdownText: View {
     // MARK: Lifecycle
 
-    init(_ text: String, color: Color = .white.opacity(0.9), fontSize: CGFloat = 13) {
+    init(_ text: String, color: Color = .white.opacity(0.9), fontSize: CGFloat = 13, useSystemFont: Bool = false) {
         self.text = text
         self.baseColor = color
         self.fontSize = fontSize
+        self.useSystemFont = useSystemFont
         self.document = DocumentCache.shared.document(for: text)
     }
 
@@ -55,6 +56,7 @@ struct MarkdownText: View {
     let text: String
     let baseColor: Color
     let fontSize: CGFloat
+    let useSystemFont: Bool
 
     var body: some View {
         let children = Array(document.children)
@@ -62,11 +64,11 @@ struct MarkdownText: View {
             // Fallback for empty parse result
             SwiftUI.Text(self.text)
                 .foregroundColor(self.baseColor)
-                .font(.system(size: self.fontSize))
+                .font(self.useSystemFont ? .system(size: self.fontSize) : .system(size: self.fontSize, design: .monospaced))
         } else {
-            VStack(alignment: .leading, spacing: 12) {
+            VStack(alignment: .leading, spacing: 8) {
                 ForEach(Array(children.enumerated()), id: \.offset) { _, child in
-                    BlockRenderer(markup: child, baseColor: self.baseColor, fontSize: self.fontSize)
+                    BlockRenderer(markup: child, baseColor: self.baseColor, fontSize: self.fontSize, useSystemFont: self.useSystemFont)
                 }
             }
         }
@@ -85,6 +87,7 @@ private struct BlockRenderer: View {
     let markup: Markup
     let baseColor: Color
     let fontSize: CGFloat
+    let useSystemFont: Bool
 
     var body: some View {
         self.content
@@ -94,19 +97,26 @@ private struct BlockRenderer: View {
 
     @ViewBuilder private var content: some View {
         if let paragraph = markup as? Paragraph {
-            InlineRenderer(children: Array(paragraph.inlineChildren), baseColor: self.baseColor, fontSize: self.fontSize)
-                .lineSpacing(4)
-                .fixedSize(horizontal: false, vertical: true)
+            InlineRenderer(
+                children: Array(paragraph.inlineChildren),
+                baseColor: self.baseColor,
+                fontSize: self.fontSize,
+                useSystemFont: self.useSystemFont,
+            )
+            .lineSpacing(2)
+            .fixedSize(horizontal: false, vertical: true)
         } else if let heading = markup as? Heading {
             self.headingView(heading)
         } else if let codeBlock = markup as? CodeBlock {
-            CodeBlockView(code: codeBlock.code)
+            CodeBlockView(code: codeBlock.code, language: codeBlock.language)
         } else if let blockQuote = markup as? BlockQuote {
             self.blockQuoteView(blockQuote)
         } else if let list = markup as? UnorderedList {
             self.unorderedListView(list)
         } else if let list = markup as? OrderedList {
             self.orderedListView(list)
+        } else if let table = markup as? Markdown.Table {
+            self.tableView(table)
         } else if self.markup is ThematicBreak {
             Divider()
                 .background(self.baseColor.opacity(0.3))
@@ -118,7 +128,12 @@ private struct BlockRenderer: View {
 
     @ViewBuilder
     private func headingView(_ heading: Heading) -> some View {
-        let text = InlineRenderer(children: Array(heading.inlineChildren), baseColor: self.baseColor, fontSize: self.fontSize).asText()
+        let text = InlineRenderer(
+            children: Array(heading.inlineChildren),
+            baseColor: self.baseColor,
+            fontSize: self.fontSize,
+            useSystemFont: self.useSystemFont,
+        ).asText()
         switch heading.level {
         case 1: text.bold().italic().underline()
         case 2: text.bold()
@@ -135,9 +150,14 @@ private struct BlockRenderer: View {
             VStack(alignment: .leading, spacing: 4) {
                 ForEach(Array(blockQuote.children.enumerated()), id: \.offset) { _, child in
                     if let para = child as? Paragraph {
-                        InlineRenderer(children: Array(para.inlineChildren), baseColor: self.baseColor.opacity(0.7), fontSize: self.fontSize)
-                            .asText()
-                            .italic()
+                        InlineRenderer(
+                            children: Array(para.inlineChildren),
+                            baseColor: self.baseColor.opacity(0.7),
+                            fontSize: self.fontSize,
+                            useSystemFont: self.useSystemFont,
+                        )
+                        .asText()
+                        .italic()
                     }
                 }
             }
@@ -149,17 +169,34 @@ private struct BlockRenderer: View {
         VStack(alignment: .leading, spacing: 4) {
             ForEach(Array(list.listItems.enumerated()), id: \.offset) { _, item in
                 HStack(alignment: .top, spacing: 6) {
-                    SwiftUI.Text("•")
-                        .font(.system(size: self.fontSize))
-                        .foregroundColor(self.baseColor.opacity(0.6))
-                        .frame(width: 12, alignment: .center)
+                    if let checkbox = item.checkbox {
+                        Image(systemName: checkbox == .checked ? "checkmark.square.fill" : "square")
+                            .font(.system(size: self.fontSize - 1))
+                            .foregroundColor(checkbox == .checked ? Color.green.opacity(0.8) : self.baseColor.opacity(0.5))
+                            .frame(width: 12, alignment: .center)
+                    } else {
+                        SwiftUI.Text("\u{2022}")
+                            .font(.system(size: self.fontSize))
+                            .foregroundColor(self.baseColor.opacity(0.6))
+                            .frame(width: 12, alignment: .center)
+                    }
 
                     VStack(alignment: .leading, spacing: 4) {
                         ForEach(Array(item.children.enumerated()), id: \.offset) { _, child in
                             if let para = child as? Paragraph {
-                                InlineRenderer(children: Array(para.inlineChildren), baseColor: self.baseColor, fontSize: self.fontSize)
+                                InlineRenderer(
+                                    children: Array(para.inlineChildren),
+                                    baseColor: self.baseColor,
+                                    fontSize: self.fontSize,
+                                    useSystemFont: self.useSystemFont,
+                                )
                             } else {
-                                Self(markup: child, baseColor: self.baseColor, fontSize: self.fontSize)
+                                Self(
+                                    markup: child,
+                                    baseColor: self.baseColor,
+                                    fontSize: self.fontSize,
+                                    useSystemFont: self.useSystemFont,
+                                )
                             }
                         }
                     }
@@ -180,15 +217,75 @@ private struct BlockRenderer: View {
                     VStack(alignment: .leading, spacing: 4) {
                         ForEach(Array(item.children.enumerated()), id: \.offset) { _, child in
                             if let para = child as? Paragraph {
-                                InlineRenderer(children: Array(para.inlineChildren), baseColor: self.baseColor, fontSize: self.fontSize)
+                                InlineRenderer(
+                                    children: Array(para.inlineChildren),
+                                    baseColor: self.baseColor,
+                                    fontSize: self.fontSize,
+                                    useSystemFont: self.useSystemFont,
+                                )
                             } else {
-                                Self(markup: child, baseColor: self.baseColor, fontSize: self.fontSize)
+                                Self(
+                                    markup: child,
+                                    baseColor: self.baseColor,
+                                    fontSize: self.fontSize,
+                                    useSystemFont: self.useSystemFont,
+                                )
                             }
                         }
                     }
                 }
             }
         }
+    }
+
+    private func tableView(_ table: Markdown.Table) -> some View {
+        let head = table.head
+        let body = table.body
+
+        return ScrollView(.horizontal, showsIndicators: false) {
+            Grid(alignment: .leading, horizontalSpacing: 0, verticalSpacing: 0) {
+                GridRow {
+                    ForEach(Array(head.cells.enumerated()), id: \.offset) { _, cell in
+                        InlineRenderer(
+                            children: Array(cell.inlineChildren),
+                            baseColor: self.baseColor,
+                            fontSize: self.fontSize,
+                            useSystemFont: self.useSystemFont,
+                        )
+                        .asText()
+                        .bold()
+                        .padding(.horizontal, 10)
+                        .padding(.vertical, 6)
+                        .frame(maxWidth: .infinity, alignment: .leading)
+                        .background(Color.white.opacity(0.12))
+                    }
+                }
+
+                ForEach(Array(body.rows.enumerated()), id: \.offset) { rowIndex, row in
+                    GridRow {
+                        ForEach(Array(row.cells.enumerated()), id: \.offset) { _, cell in
+                            InlineRenderer(
+                                children: Array(cell.inlineChildren),
+                                baseColor: self.baseColor,
+                                fontSize: self.fontSize,
+                                useSystemFont: self.useSystemFont,
+                            )
+                            .padding(.horizontal, 10)
+                            .padding(.vertical, 6)
+                            .frame(maxWidth: .infinity, alignment: .leading)
+                            .background(rowIndex.isMultiple(of: 2) ? Color.white.opacity(0.04) : Color.clear)
+                        }
+                    }
+                }
+            }
+            .fixedSize()
+        }
+        .background(Color.white.opacity(0.04))
+        .cornerRadius(6)
+        .overlay(
+            RoundedRectangle(cornerRadius: 6)
+                .stroke(Color.white.opacity(0.15), lineWidth: 0.5),
+        )
     }
 }
 
@@ -200,6 +297,7 @@ private struct InlineRenderer: View {
     let children: [InlineMarkup]
     let baseColor: Color
     let fontSize: CGFloat
+    let useSystemFont: Bool
 
     var body: some View {
         self.asText()
@@ -216,17 +314,23 @@ private struct InlineRenderer: View {
 
     // MARK: Private
 
+    private var bodyFont: Font {
+        self.useSystemFont ? .system(size: self.fontSize) : .system(size: self.fontSize, design: .monospaced)
+    }
+
     private func renderInline(_ inline: InlineMarkup) -> SwiftUI.Text {
         if let text = inline as? Markdown.Text {
-            return SwiftUI.Text(text.string).foregroundColor(self.baseColor)
+            return SwiftUI.Text(text.string)
+                .font(self.bodyFont)
+                .foregroundColor(self.baseColor)
         } else if let strong = inline as? Strong {
-            let plainText = strong.plainText
-            return SwiftUI.Text(plainText)
+            return SwiftUI.Text(strong.plainText)
+                .font(self.bodyFont)
                 .fontWeight(.bold)
                 .foregroundColor(self.baseColor)
         } else if let emphasis = inline as? Emphasis {
-            let plainText = emphasis.plainText
-            return SwiftUI.Text(plainText)
+            return SwiftUI.Text(emphasis.plainText)
+                .font(self.bodyFont)
                 .italic()
                 .foregroundColor(self.baseColor)
         } else if let code = inline as? InlineCode {
@@ -234,13 +338,13 @@ private struct InlineRenderer: View {
                 .font(.system(size: self.fontSize, design: .monospaced))
                 .foregroundColor(self.baseColor)
         } else if let link = inline as? Markdown.Link {
-            let plainText = link.plainText
-            return SwiftUI.Text(plainText)
+            return SwiftUI.Text(link.plainText)
+                .font(self.bodyFont)
                 .foregroundColor(Color.blue)
                 .underline()
         } else if let strike = inline as? Strikethrough {
-            let plainText = strike.plainText
-            return SwiftUI.Text(plainText)
+            return SwiftUI.Text(strike.plainText)
+                .font(self.bodyFont)
                 .strikethrough()
                 .foregroundColor(self.baseColor)
         } else if inline is SoftBreak {
@@ -248,7 +352,9 @@ private struct InlineRenderer: View {
         } else if inline is LineBreak {
             return SwiftUI.Text("\n")
         } else {
-            return SwiftUI.Text(inline.plainText).foregroundColor(self.baseColor)
+            return SwiftUI.Text(inline.plainText)
+                .font(self.bodyFont)
+                .foregroundColor(self.baseColor)
         }
     }
 
@@ -265,17 +371,54 @@ private struct InlineRenderer: View {
 // MARK: - CodeBlockView
 
 private struct CodeBlockView: View {
+    // MARK: Internal
+
     let code: String
+    let language: String?
 
     var body: some View {
-        ScrollView(.horizontal, showsIndicators: false) {
-            SwiftUI.Text(self.code)
-                .font(.system(size: 11, design: .monospaced))
-                .foregroundColor(.white.opacity(0.85))
-                .padding(10)
+        VStack(spacing: 0) {
+            if let language, !language.isEmpty {
+                HStack {
+                    SwiftUI.Text(language)
+                        .font(.system(size: 10, weight: .medium))
+                        .foregroundColor(.white.opacity(0.5))
+
+                    Spacer()
+
+                    Button {
+                        NSPasteboard.general.clearContents()
+                        NSPasteboard.general.setString(self.code, forType: .string)
+                        self.showCopied = true
+                        Task(name: "copy-feedback") {
+                            try? await Task.sleep(for: .seconds(1.5))
+                            self.showCopied = false
+                        }
+                    } label: {
+                        Image(systemName: self.showCopied ? "checkmark" : "doc.on.doc")
+                            .font(.system(size: 10))
+                            .foregroundColor(.white.opacity(0.5))
+                    }
+                    .buttonStyle(.plain)
+                }
+                .padding(.horizontal, 10)
+                .padding(.vertical, 6)
+                .background(Color.white.opacity(0.12))
+            }
+
+            ScrollView(.horizontal, showsIndicators: false) {
+                SwiftUI.Text(self.code)
+                    .font(.system(size: 11, design: .monospaced))
+                    .foregroundColor(.white.opacity(0.85))
+                    .padding(10)
+            }
+            .frame(maxWidth: .infinity, alignment: .leading)
         }
-        .frame(maxWidth: .infinity, alignment: .leading)
         .background(Color.white.opacity(0.08))
         .cornerRadius(6)
     }
+
+    // MARK: Private
+
+    @State private var showCopied = false
 }

--- a/ClaudeIsland/UI/Components/ThinkingBlockView.swift
+++ b/ClaudeIsland/UI/Components/ThinkingBlockView.swift
@@ -1,0 +1,66 @@
+//
+//  ThinkingBlockView.swift
+//  ClaudeIsland
+//
+//  Collapsed thinking block with expand toggle
+//
+
+import SwiftUI
+
+struct ThinkingBlockView: View {
+    // MARK: Internal
+
+    let text: String
+
+    var body: some View {
+        VStack(alignment: .leading, spacing: 0) {
+            Button {
+                withAnimation(.spring(response: 0.25, dampingFraction: 0.8)) {
+                    self.isExpanded.toggle()
+                }
+            } label: {
+                HStack(spacing: 5) {
+                    Image(systemName: "chevron.right")
+                        .font(.system(size: 8, weight: .medium))
+                        .foregroundColor(.white.opacity(0.2))
+                        .rotationEffect(.degrees(self.isExpanded ? 90 : 0))
+
+                    Text("Thinking...")
+                        .font(.system(size: 10))
+                        .foregroundColor(.white.opacity(0.25))
+                        .italic()
+
+                    Spacer()
+                }
+                .padding(.vertical, 5)
+                .padding(.horizontal, 8)
+                .contentShape(Rectangle())
+            }
+            .buttonStyle(.plain)
+
+            if self.isExpanded {
+                Text(self.text)
+                    .font(.system(size: 10))
+                    .foregroundColor(.white.opacity(0.3))
+                    .italic()
+                    .lineSpacing(2)
+                    .padding(.horizontal, 8)
+                    .padding(.bottom, 6)
+                    .padding(.leading, 15)
+                    .transition(.opacity.combined(with: .move(edge: .top)))
+            }
+        }
+        .background(Color.white.opacity(0.03))
+        .cornerRadius(4)
+        .overlay(alignment: .leading) {
+            Rectangle()
+                .fill(Color.white.opacity(0.08))
+                .frame(width: 2)
+        }
+        .frame(maxWidth: .infinity, alignment: .leading)
+    }
+
+    // MARK: Private
+
+    @State private var isExpanded = false
+}

--- a/ClaudeIsland/UI/Components/ToolCallInlineView.swift
+++ b/ClaudeIsland/UI/Components/ToolCallInlineView.swift
@@ -1,0 +1,221 @@
+//
+//  ToolCallInlineView.swift
+//  ClaudeIsland
+//
+//  Terminal mode inline tool call with status dot, name, content
+//
+
+import SwiftUI
+
+// MARK: - ToolCallInlineView
+
+struct ToolCallInlineView: View {
+    // MARK: Internal
+
+    let tool: ToolCallItem
+    let onApprove: (() -> Void)?
+    let onDeny: (() -> Void)?
+
+    var body: some View {
+        let isApproval = self.tool.status == .waitingForApproval
+
+        VStack(alignment: .leading, spacing: 4) {
+            // Status line
+            self.statusLine
+
+            // Approval buttons
+            if isApproval, let onApprove, let onDeny {
+                HStack(spacing: 8) {
+                    Button {
+                        onApprove()
+                    } label: {
+                        Text("Allow")
+                            .font(.system(size: 10, weight: .semibold))
+                            .foregroundColor(Color(red: 0.051, green: 0.067, blue: 0.09))
+                            .padding(.horizontal, 14)
+                            .padding(.vertical, 4)
+                            .background(Color.white.opacity(0.9))
+                            .cornerRadius(4)
+                    }
+                    .buttonStyle(.plain)
+
+                    Button {
+                        onDeny()
+                    } label: {
+                        Text("Deny")
+                            .font(.system(size: 10, weight: .medium))
+                            .foregroundColor(.white.opacity(0.5))
+                            .padding(.horizontal, 14)
+                            .padding(.vertical, 4)
+                            .background(Color.white.opacity(0.08))
+                            .cornerRadius(4)
+                    }
+                    .buttonStyle(.plain)
+                }
+                .padding(.leading, 12)
+            }
+
+            // Content block
+            if self.shouldShowContent {
+                self.contentBlock
+                    .padding(.leading, 12)
+            }
+        }
+        .padding(isApproval ? 8 : 0)
+        .padding(.leading, isApproval ? 2 : 0)
+        .background(
+            isApproval
+                ? RoundedRectangle(cornerRadius: 6)
+                .fill(Color(red: 0.824, green: 0.6, blue: 0.133).opacity(0.06))
+                .overlay(
+                    RoundedRectangle(cornerRadius: 6)
+                        .stroke(Color(red: 0.824, green: 0.6, blue: 0.133).opacity(0.15), lineWidth: 1),
+                )
+                : nil,
+        )
+        .frame(maxWidth: .infinity, alignment: .leading)
+    }
+
+    // MARK: Private
+
+    @State private var pulseOpacity = 0.6
+
+    private var isAnimating: Bool {
+        self.tool.status == .running || self.tool.status == .waitingForApproval
+    }
+
+    private var toolDisplayName: String {
+        MCPToolFormatter.formatToolName(self.tool.name)
+    }
+
+    private var inputPreview: String {
+        self.tool.inputPreview
+    }
+
+    private var rightStatusText: String? {
+        switch self.tool.status {
+        case .running:
+            return "Running..."
+        case .waitingForApproval:
+            return "Waiting for approval"
+        default:
+            let display = self.tool.statusDisplay
+            return display.text.isEmpty ? nil : display.text
+        }
+    }
+
+    private var shouldShowContent: Bool {
+        // Edit always shows diff
+        if self.tool.name == "Edit" {
+            return true
+        }
+        // Task shows subagent tools list
+        if self.tool.name == "Task" && !self.tool.subagentTools.isEmpty {
+            return true
+        }
+        // Running tools don't show content yet (except Edit)
+        if self.tool.status == .running || self.tool.status == .waitingForApproval {
+            return false
+        }
+        // Tools with no result
+        let hasResult = self.tool.result != nil || self.tool.structuredResult != nil
+        if !hasResult {
+            return false
+        }
+        // Bash with empty output
+        if self.tool.name == "Bash" || self.tool.name == "bash" {
+            if let result = self.tool.result, result.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty {
+                return false
+            }
+        }
+        return true
+    }
+
+    private var statusLine: some View {
+        HStack(spacing: 6) {
+            Circle()
+                .fill(ToolStatusColors.color(for: self.tool.status).opacity(self.isAnimating ? self.pulseOpacity : 0.6))
+                .frame(width: 6, height: 6)
+                .shadow(color: self.isAnimating ? ToolStatusColors.color(for: self.tool.status).opacity(0.5) : .clear, radius: 3)
+                .id(self.tool.status)
+                .onAppear {
+                    if self.isAnimating {
+                        withAnimation(.easeInOut(duration: 0.6).repeatForever(autoreverses: true)) {
+                            self.pulseOpacity = 0.15
+                        }
+                    }
+                }
+
+            Text(self.toolDisplayName)
+                .font(.system(size: 10, weight: .medium, design: .monospaced))
+                .foregroundColor(self.tool.status == .error ? Color(red: 0.973, green: 0.318, blue: 0.286) : .white.opacity(0.45))
+
+            Text("\u{00B7}")
+                .font(.system(size: 10, design: .monospaced))
+                .foregroundColor(.white.opacity(0.25))
+
+            Text(self.inputPreview)
+                .font(.system(size: 10, design: .monospaced))
+                .foregroundColor(Color(red: 0.345, green: 0.651, blue: 1.0))
+                .lineLimit(1)
+                .truncationMode(.middle)
+
+            Spacer()
+
+            if let statusText = self.rightStatusText {
+                Text(statusText)
+                    .font(.system(size: 9, design: .monospaced))
+                    .foregroundColor(self.tool.status == .error ? Color(red: 0.973, green: 0.318, blue: 0.286).opacity(0.8) : .white.opacity(0.3))
+                    .lineLimit(1)
+            }
+        }
+    }
+
+    @ViewBuilder private var contentBlock: some View {
+        let isError = self.tool.status == .error
+
+        if self.tool.name == "Task" && !self.tool.subagentTools.isEmpty {
+            SubagentToolsList(tools: self.tool.subagentTools)
+                .padding(.top, 2)
+        } else if self.tool.name == "Edit" && self.tool.status == .running {
+            EditInputDiffView(input: self.tool.input)
+                .padding(.top, 4)
+        } else {
+            let lineCount = self.estimateLineCount()
+            let needsCap = lineCount > 8
+
+            Group {
+                if needsCap {
+                    CollapsibleContentView(lineCount: lineCount) {
+                        self.resultContent
+                    }
+                } else {
+                    self.resultContent
+                }
+            }
+            .padding(.top, 4)
+            .padding(isError ? 4 : 0)
+            .background(
+                isError
+                    ? RoundedRectangle(cornerRadius: 4)
+                    .fill(Color(red: 0.973, green: 0.318, blue: 0.286).opacity(0.06))
+                    .overlay(
+                        RoundedRectangle(cornerRadius: 4)
+                            .stroke(Color(red: 0.973, green: 0.318, blue: 0.286).opacity(0.1), lineWidth: 1),
+                    )
+                    : nil,
+            )
+        }
+    }
+
+    private var resultContent: some View {
+        ToolResultContent(tool: self.tool)
+    }
+
+    private func estimateLineCount() -> Int {
+        if let result = self.tool.result {
+            return result.components(separatedBy: "\n").count
+        }
+        return 0
+    }
+}

--- a/ClaudeIsland/UI/Components/ToolCallSummaryView.swift
+++ b/ClaudeIsland/UI/Components/ToolCallSummaryView.swift
@@ -1,0 +1,62 @@
+//
+//  ToolCallSummaryView.swift
+//  ClaudeIsland
+//
+//  Chat mode compact one-line tool summary
+//
+
+import SwiftUI
+
+struct ToolCallSummaryView: View {
+    // MARK: Internal
+
+    let tool: ToolCallItem
+
+    var body: some View {
+        HStack(spacing: 6) {
+            Circle()
+                .fill(ToolStatusColors.color(for: self.tool.status).opacity(self.isAnimating ? self.pulseOpacity : 0.6))
+                .frame(width: 5, height: 5)
+                .id(self.tool.status)
+                .onAppear {
+                    if self.isAnimating {
+                        withAnimation(.easeInOut(duration: 0.6).repeatForever(autoreverses: true)) {
+                            self.pulseOpacity = 0.15
+                        }
+                    }
+                }
+
+            Text(self.summaryText)
+                .font(.system(size: 11))
+                .foregroundColor(.white.opacity(0.35))
+                .lineLimit(1)
+                .truncationMode(.tail)
+        }
+    }
+
+    // MARK: Private
+
+    @State private var pulseOpacity = 0.6
+
+    private var isAnimating: Bool {
+        self.tool.status == .running || self.tool.status == .waitingForApproval
+    }
+
+    private var summaryText: String {
+        if self.tool.status == .running {
+            return ToolStatusDisplay.running(for: self.tool.name, input: self.tool.input).text
+        }
+        if self.tool.status == .waitingForApproval {
+            return "Waiting for approval"
+        }
+        if self.tool.status == .interrupted {
+            return "Interrupted"
+        }
+        let completed = ToolStatusDisplay.completed(for: self.tool.name, result: self.tool.structuredResult).text
+        if completed == "Completed" && !self.tool.inputPreview.isEmpty {
+            let name = MCPToolFormatter.formatToolName(self.tool.name)
+            return "\(name): \(self.tool.inputPreview)"
+        }
+        return completed
+    }
+}

--- a/ClaudeIsland/UI/Components/ToolStatusColors.swift
+++ b/ClaudeIsland/UI/Components/ToolStatusColors.swift
@@ -1,0 +1,24 @@
+//
+//  ToolStatusColors.swift
+//  ClaudeIsland
+//
+//  Shared status color palette for tool call views
+//
+
+import SwiftUI
+
+enum ToolStatusColors {
+    static let running = Color.white
+    static let waitingForApproval = Color(red: 0.824, green: 0.6, blue: 0.133)
+    static let success = Color(red: 0.247, green: 0.725, blue: 0.314)
+    static let error = Color(red: 0.973, green: 0.318, blue: 0.286)
+
+    static func color(for status: ToolStatus) -> Color {
+        switch status {
+        case .running: self.running
+        case .waitingForApproval: self.waitingForApproval
+        case .success: self.success
+        case .error, .interrupted: self.error
+        }
+    }
+}

--- a/ClaudeIsland/UI/Views/ChatModeView.swift
+++ b/ClaudeIsland/UI/Views/ChatModeView.swift
@@ -1,0 +1,127 @@
+//
+//  ChatModeView.swift
+//  ClaudeIsland
+//
+//  Chat mode: iMessage-style bubbles with compact tool summaries
+//
+
+import SwiftUI
+
+// MARK: - ChatModeView
+
+struct ChatModeView: View {
+    // MARK: Internal
+
+    let item: ChatHistoryItem
+    let sessionID: String
+
+    var body: some View {
+        switch self.item.type {
+        case let .user(text):
+            self.userBubble(text)
+        case let .assistant(text):
+            self.assistantBubble {
+                MarkdownText(
+                    text,
+                    color: ChatMessageHelpers.isErrorMessage(text) ? self.errorRed.opacity(0.9) : .white.opacity(0.9),
+                    fontSize: 13,
+                    useSystemFont: true,
+                )
+            }
+        case let .toolCall(tool):
+            self.assistantBubble {
+                VStack(alignment: .leading, spacing: 0) {
+                    Rectangle()
+                        .fill(Color.white.opacity(0.06))
+                        .frame(height: 1)
+                        .padding(.bottom, 6)
+
+                    ToolCallSummaryView(tool: tool)
+                }
+            }
+        case let .thinking(text):
+            if !text.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty {
+                self.assistantBubble {
+                    ThinkingBlockView(text: text)
+                }
+            }
+        case .interrupted:
+            self.assistantBubble {
+                Text("Interrupted")
+                    .font(.system(size: 13))
+                    .foregroundColor(Color(red: 0.973, green: 0.318, blue: 0.286))
+            }
+        }
+    }
+
+    // MARK: Private
+
+    private let bubbleBlue = Color(red: 0.145, green: 0.388, blue: 0.922)
+    private let avatarPurple = Color(red: 0.486, green: 0.227, blue: 0.929)
+    private let errorRed = Color(red: 0.973, green: 0.318, blue: 0.286)
+
+    private func userBubble(_ text: String) -> some View {
+        HStack {
+            Spacer(minLength: 60)
+
+            MarkdownText(text, color: .white, fontSize: 13, useSystemFont: true)
+                .padding(.horizontal, 14)
+                .padding(.vertical, 10)
+                .background(
+                    BubbleShape(isUser: true)
+                        .fill(self.bubbleBlue),
+                )
+        }
+    }
+
+    private func assistantBubble(@ViewBuilder content: () -> some View) -> some View {
+        HStack(alignment: .top, spacing: 10) {
+            Text("C")
+                .font(.system(size: 10, weight: .semibold))
+                .foregroundColor(.white)
+                .frame(width: 24, height: 24)
+                .background(Circle().fill(self.avatarPurple))
+
+            content()
+                .frame(maxWidth: 600, alignment: .leading)
+                .padding(.horizontal, 14)
+                .padding(.vertical, 10)
+                .background(
+                    BubbleShape(isUser: false)
+                        .fill(Color.white.opacity(0.04)),
+                )
+
+            Spacer(minLength: 40)
+        }
+    }
+}
+
+// MARK: - BubbleShape
+
+private struct BubbleShape: Shape {
+    let isUser: Bool
+
+    func path(in rect: CGRect) -> Path {
+        if self.isUser {
+            Path(
+                roundedRect: rect,
+                cornerRadii: RectangleCornerRadii(
+                    topLeading: 16,
+                    bottomLeading: 16,
+                    bottomTrailing: 4,
+                    topTrailing: 16,
+                ),
+            )
+        } else {
+            Path(
+                roundedRect: rect,
+                cornerRadii: RectangleCornerRadii(
+                    topLeading: 4,
+                    bottomLeading: 16,
+                    bottomTrailing: 16,
+                    topTrailing: 16,
+                ),
+            )
+        }
+    }
+}

--- a/ClaudeIsland/UI/Views/ChatView.swift
+++ b/ClaudeIsland/UI/Views/ChatView.swift
@@ -153,7 +153,6 @@ struct ChatView: View {
             }
         }
         .onChange(of: self.canSendMessages) { _, canSend in
-            // Auto-focus input when tmux messaging becomes available
             if canSend && !self.isInputFocused {
                 self.focusInputTask?.cancel()
                 self.focusInputTask = Task(name: "auto-focus-input") {
@@ -205,6 +204,10 @@ struct ChatView: View {
     @State private var keyEventMonitor: Any?
     @FocusState private var isInputFocused: Bool
 
+    // swiftformat:disable:next wrapAttributes
+    @AppStorage("chatViewMode")
+    private var chatViewMode: String = ChatViewMode.terminal.rawValue
+
     // MARK: - Header
 
     @State private var isHeaderHovered = false
@@ -213,6 +216,10 @@ struct ChatView: View {
 
     /// Background color for fade gradients
     private let fadeColor = Color(red: 0.00, green: 0.00, blue: 0.00)
+
+    private var currentMode: ChatViewMode {
+        ChatViewMode(rawValue: self.chatViewMode) ?? .terminal
+    }
 
     /// Access to chat history from @Observable manager for SwiftUI observation
     private var chatManagerHistory: [ChatHistoryItem] {
@@ -262,33 +269,37 @@ struct ChatView: View {
     }
 
     private var chatHeader: some View {
-        Button {
-            self.viewModel.exitChat()
-        } label: {
-            HStack(spacing: 8) {
-                Image(systemName: "chevron.left")
-                    .font(.system(size: 14, weight: .semibold))
-                    .foregroundColor(.white.opacity(self.isHeaderHovered ? 1.0 : 0.6))
-                    .frame(width: 24, height: 24)
+        HStack(spacing: 8) {
+            Button {
+                self.viewModel.exitChat()
+            } label: {
+                HStack(spacing: 8) {
+                    Image(systemName: "chevron.left")
+                        .font(.system(size: 14, weight: .semibold))
+                        .foregroundColor(.white.opacity(self.isHeaderHovered ? 1.0 : 0.6))
+                        .frame(width: 24, height: 24)
 
-                Text(self.session.displayTitle)
-                    .font(.system(size: 14, weight: .semibold))
-                    .foregroundColor(.white.opacity(self.isHeaderHovered ? 1.0 : 0.85))
-                    .lineLimit(1)
-
-                Spacer()
+                    Text(self.session.displayTitle)
+                        .font(.system(size: 14, weight: .semibold))
+                        .foregroundColor(.white.opacity(self.isHeaderHovered ? 1.0 : 0.85))
+                        .lineLimit(1)
+                }
             }
-            .padding(.horizontal, 12)
-            .padding(.vertical, 10)
-            .background(
-                RoundedRectangle(cornerRadius: 8)
-                    .fill(self.isHeaderHovered ? Color.white.opacity(0.08) : Color.clear),
-            )
+            .buttonStyle(.plain)
+            .onHover { self.isHeaderHovered = $0 }
+
+            Spacer()
+
+            Picker("", selection: self.$chatViewMode) {
+                Text("Terminal").tag(ChatViewMode.terminal.rawValue)
+                Text("Chat").tag(ChatViewMode.chat.rawValue)
+            }
+            .pickerStyle(.segmented)
+            .frame(width: 140)
+            .labelsHidden()
         }
-        .buttonStyle(.plain)
-        .onHover { self.isHeaderHovered = $0 }
-        .padding(.horizontal, 8)
-        .padding(.vertical, 4)
+        .padding(.horizontal, 12)
+        .padding(.vertical, 10)
         .background(Color.black.opacity(0.2))
         .overlay(alignment: .bottom) {
             LinearGradient(
@@ -297,10 +308,10 @@ struct ChatView: View {
                 endPoint: .bottom,
             )
             .frame(height: 24)
-            .offset(y: 24) // Push below header
+            .offset(y: 24)
             .allowsHitTesting(false)
         }
-        .zIndex(1) // Render above message list
+        .zIndex(1)
     }
 
     // MARK: - Loading State
@@ -334,7 +345,7 @@ struct ChatView: View {
     private var messageList: some View {
         ScrollViewReader { proxy in
             ScrollView(.vertical, showsIndicators: false) {
-                LazyVStack(spacing: 16) {
+                LazyVStack(spacing: self.currentMode == .terminal ? 8 : 12) {
                     // Invisible anchor at bottom (first due to flip)
                     Color.clear
                         .frame(height: 1)
@@ -352,13 +363,24 @@ struct ChatView: View {
                     }
 
                     ForEach(self.history.reversed()) { item in
-                        MessageItemView(item: item, sessionID: self.sessionID)
-                            .padding(.horizontal, 16)
-                            .scaleEffect(x: 1, y: -1)
-                            .transition(.asymmetric(
-                                insertion: .opacity.combined(with: .scale(scale: 0.98)),
-                                removal: .opacity,
-                            ))
+                        Group {
+                            switch self.currentMode {
+                            case .terminal:
+                                TerminalModeView(
+                                    item: item,
+                                    onApprove: { self.approvePermission() },
+                                    onDeny: { self.denyPermission() },
+                                )
+                            case .chat:
+                                ChatModeView(item: item, sessionID: self.sessionID)
+                            }
+                        }
+                        .padding(.horizontal, 16)
+                        .scaleEffect(x: 1, y: -1)
+                        .transition(.asymmetric(
+                            insertion: .opacity.combined(with: .scale(scale: 0.98)),
+                            removal: .opacity,
+                        ))
                     }
                 }
                 .padding(.top, 20)
@@ -740,68 +762,6 @@ struct ChatView: View {
     }
 }
 
-// MARK: - MessageItemView
-
-struct MessageItemView: View {
-    let item: ChatHistoryItem
-    let sessionID: String
-
-    var body: some View {
-        switch self.item.type {
-        case let .user(text):
-            UserMessageView(text: text)
-        case let .assistant(text):
-            AssistantMessageView(text: text)
-        case let .toolCall(tool):
-            ToolCallView(tool: tool, sessionID: self.sessionID)
-        case let .thinking(text):
-            ThinkingView(text: text)
-        case .interrupted:
-            InterruptedMessageView()
-        }
-    }
-}
-
-// MARK: - UserMessageView
-
-struct UserMessageView: View {
-    let text: String
-
-    var body: some View {
-        HStack {
-            Spacer(minLength: 60)
-
-            MarkdownText(self.text, color: .white, fontSize: 13)
-                .padding(.horizontal, 14)
-                .padding(.vertical, 10)
-                .background(
-                    RoundedRectangle(cornerRadius: 18)
-                        .fill(Color.white.opacity(0.15)),
-                )
-        }
-    }
-}
-
-// MARK: - AssistantMessageView
-
-struct AssistantMessageView: View {
-    let text: String
-
-    var body: some View {
-        HStack(alignment: .top, spacing: 6) {
-            // White dot indicator
-            Circle()
-                .fill(Color.white.opacity(0.6))
-                .frame(width: 6, height: 6)
-                .padding(.top, 5)
-
-            MarkdownText(self.text, color: .white.opacity(0.9), fontSize: 13)
-
-            Spacer(minLength: 60)
-        }
-    }
-}
-
 // MARK: - ProcessingIndicatorView
 
 struct ProcessingIndicatorView: View {
@@ -837,216 +797,6 @@ struct ProcessingIndicatorView: View {
     private let baseTexts = ["Processing", "Working"]
     private let color = Color(red: 0.85, green: 0.47, blue: 0.34) // Claude orange
     private let baseText: String
-}
-
-// MARK: - ToolCallView
-
-struct ToolCallView: View {
-    // MARK: Internal
-
-    let tool: ToolCallItem
-    let sessionID: String
-
-    var body: some View {
-        VStack(alignment: .leading, spacing: 4) {
-            HStack(spacing: 6) {
-                Circle()
-                    .fill(self.statusColor.opacity(self.tool.status == .running || self.tool.status == .waitingForApproval ? self.pulseOpacity : 0.6))
-                    .frame(width: 6, height: 6)
-                    .id(self.tool.status) // Forces view recreation, cancelling repeatForever animation
-                    .onAppear {
-                        if self.tool.status == .running || self.tool.status == .waitingForApproval {
-                            self.startPulsing()
-                        }
-                    }
-
-                // Tool name (formatted for MCP tools, verbose when enabled)
-                Text(self.verboseToolName)
-                    .font(.system(size: 12, weight: .medium))
-                    .foregroundColor(self.textColor)
-                    .lineLimit(1)
-                    .truncationMode(.middle)
-
-                if self.tool.name == "Task" && !self.tool.subagentTools.isEmpty {
-                    let taskDesc = self.tool.input["description"] ?? "Running agent..."
-                    Text("\(taskDesc) (\(self.tool.subagentTools.count) tools)")
-                        .font(.system(size: 11))
-                        .foregroundColor(self.textColor.opacity(0.7))
-                        .lineLimit(1)
-                        .truncationMode(.tail)
-                } else if self.tool.name == "AgentOutputTool", let desc = agentDescription {
-                    let blocking = self.tool.input["block"] == "true"
-                    Text(blocking ? "Waiting: \(desc)" : desc)
-                        .font(.system(size: 11))
-                        .foregroundColor(self.textColor.opacity(0.7))
-                        .lineLimit(1)
-                        .truncationMode(.tail)
-                } else if MCPToolFormatter.isMCPTool(self.tool.name) && !self.tool.input.isEmpty {
-                    Text(MCPToolFormatter.formatArgs(self.tool.input))
-                        .font(.system(size: 11))
-                        .foregroundColor(self.textColor.opacity(0.7))
-                        .lineLimit(1)
-                        .truncationMode(.tail)
-                } else {
-                    Text(self.tool.statusDisplay.text)
-                        .font(.system(size: 11))
-                        .foregroundColor(self.textColor.opacity(0.7))
-                        .lineLimit(1)
-                        .truncationMode(.tail)
-                }
-
-                Spacer()
-
-                // Expand indicator (only for expandable tools)
-                if self.canExpand && self.tool.status != .running && self.tool.status != .waitingForApproval {
-                    Image(systemName: "chevron.right")
-                        .font(.system(size: 9, weight: .medium))
-                        .foregroundColor(.white.opacity(0.3))
-                        .rotationEffect(.degrees(self.isExpanded ? 90 : 0))
-                        .animation(.spring(response: 0.25, dampingFraction: 0.8), value: self.isExpanded)
-                }
-            }
-
-            if self.verboseMode && self.tool.status != .running && self.tool.status != .waitingForApproval {
-                if let preview = self.outputPreview {
-                    Text(preview)
-                        .font(.system(size: 10, design: .monospaced))
-                        .foregroundColor(.white.opacity(0.35))
-                        .lineLimit(3)
-                        .frame(maxWidth: .infinity, alignment: .leading)
-                        .padding(.leading, 12)
-                        .padding(.top, 2)
-                }
-            }
-
-            // Subagent tools list (for Task tools)
-            if self.tool.name == "Task" && !self.tool.subagentTools.isEmpty {
-                SubagentToolsList(tools: self.tool.subagentTools)
-                    .padding(.leading, 12)
-                    .padding(.top, 2)
-            }
-
-            // Result content (Edit always shows, others when expanded)
-            // Edit tools bypass hasResult check - fallback in ToolResultContent renders from input params
-            if self.showContent && self.tool.status != .running && self.tool.name != "Task" && (self.hasResult || self.tool.name == "Edit") {
-                ToolResultContent(tool: self.tool)
-                    .padding(.leading, 12)
-                    .padding(.top, 4)
-                    .transition(.opacity.combined(with: .move(edge: .top)))
-            }
-
-            // Edit tools show diff from input even while running
-            if self.tool.name == "Edit" && self.tool.status == .running {
-                EditInputDiffView(input: self.tool.input)
-                    .padding(.leading, 12)
-                    .padding(.top, 4)
-            }
-        }
-        .frame(maxWidth: .infinity, alignment: .leading)
-        .background(
-            RoundedRectangle(cornerRadius: 6)
-                .fill(self.canExpand && self.isHovering ? Color.white.opacity(0.05) : Color.clear),
-        )
-        .contentShape(Rectangle())
-        .onHover { hovering in
-            self.isHovering = hovering
-        }
-        .onTapGesture {
-            if self.canExpand {
-                withAnimation(.spring(response: 0.25, dampingFraction: 0.8)) {
-                    self.isExpanded.toggle()
-                }
-            }
-        }
-        .animation(.easeOut(duration: 0.15), value: self.isHovering)
-        .animation(.spring(response: 0.25, dampingFraction: 0.8), value: self.isExpanded)
-    }
-
-    // MARK: Private
-
-    // swiftformat:disable:next wrapAttributes
-    @AppStorage("verboseMode")
-    private var verboseMode = false
-    @State private var pulseOpacity = 0.6
-    @State private var isExpanded = false
-    @State private var isHovering = false
-
-    private var statusColor: Color {
-        switch self.tool.status {
-        case .running:
-            Color.white
-        case .waitingForApproval:
-            Color.orange
-        case .success:
-            Color.green
-        case .error,
-             .interrupted:
-            Color.red
-        }
-    }
-
-    private var textColor: Color {
-        switch self.tool.status {
-        case .running:
-            .white.opacity(0.6)
-        case .waitingForApproval:
-            Color.orange.opacity(0.9)
-        case .success:
-            .white.opacity(0.7)
-        case .error,
-             .interrupted:
-            Color.red.opacity(0.8)
-        }
-    }
-
-    private var hasResult: Bool {
-        self.tool.result != nil || self.tool.structuredResult != nil
-    }
-
-    /// Whether the tool can be expanded (has result, NOT Task tools, NOT Edit tools)
-    private var canExpand: Bool {
-        self.tool.name != "Task" && self.tool.name != "Edit" && self.hasResult
-    }
-
-    private var showContent: Bool {
-        self.tool.name == "Edit" || self.isExpanded
-    }
-
-    private var verboseToolName: String {
-        let formatted = MCPToolFormatter.formatToolName(self.tool.name)
-        if self.verboseMode {
-            return ToolStatusDisplay.verboseToolLabel(for: formatted, input: self.tool.input)
-        }
-        return formatted
-    }
-
-    private var outputPreview: String? {
-        guard let result = self.tool.result, !result.isEmpty else { return nil }
-        let lines = result.components(separatedBy: "\n")
-            .filter { !$0.trimmingCharacters(in: .whitespaces).isEmpty }
-            .prefix(3)
-            .map { String($0.prefix(80)) }
-        return lines.joined(separator: "\n")
-    }
-
-    private var agentDescription: String? {
-        guard self.tool.name == "AgentOutputTool",
-              let agentID = tool.input["agentId"],
-              let sessionDescriptions = ChatHistoryManager.shared.agentDescriptions[sessionID]
-        else {
-            return nil
-        }
-        return sessionDescriptions[agentID]
-    }
-
-    private func startPulsing() {
-        withAnimation(
-            .easeInOut(duration: 0.6)
-                .repeatForever(autoreverses: true),
-        ) {
-            self.pulseOpacity = 0.15
-        }
-    }
 }
 
 // MARK: - SubagentToolsList
@@ -1128,13 +878,7 @@ struct SubagentToolRow: View {
     @State private var dotOpacity = 0.5
 
     private var statusColor: Color {
-        switch self.tool.status {
-        case .running,
-             .waitingForApproval: .orange
-        case .success: .green
-        case .error,
-             .interrupted: .red
-        }
+        ToolStatusColors.color(for: self.tool.status)
     }
 
     /// Get status text using the same logic as regular tools
@@ -1194,71 +938,6 @@ struct SubagentToolsSummary: View {
             counts[tool.name, default: 0] += 1
         }
         return counts.sorted { $0.value > $1.value }
-    }
-}
-
-// MARK: - ThinkingView
-
-struct ThinkingView: View {
-    // MARK: Internal
-
-    let text: String
-
-    var body: some View {
-        HStack(alignment: .top, spacing: 6) {
-            Circle()
-                .fill(Color.gray.opacity(0.5))
-                .frame(width: 6, height: 6)
-                .padding(.top, 4)
-
-            Text(self.isExpanded ? self.text : String(self.text.prefix(80)) + (self.canExpand ? "..." : ""))
-                .font(.system(size: 11))
-                .foregroundColor(.gray)
-                .italic()
-                .lineLimit(self.isExpanded ? nil : 1)
-                .multilineTextAlignment(.leading)
-
-            Spacer()
-
-            if self.canExpand {
-                Image(systemName: "chevron.right")
-                    .font(.system(size: 9, weight: .medium))
-                    .foregroundColor(.gray.opacity(0.5))
-                    .rotationEffect(.degrees(self.isExpanded ? 90 : 0))
-                    .padding(.top, 3)
-            }
-        }
-        .contentShape(Rectangle())
-        .onTapGesture {
-            if self.canExpand {
-                withAnimation(.spring(response: 0.25, dampingFraction: 0.8)) {
-                    self.isExpanded.toggle()
-                }
-            }
-        }
-        .frame(maxWidth: .infinity, alignment: .leading)
-        .padding(.vertical, 2)
-    }
-
-    // MARK: Private
-
-    @State private var isExpanded = false
-
-    private var canExpand: Bool {
-        self.text.count > 80
-    }
-}
-
-// MARK: - InterruptedMessageView
-
-struct InterruptedMessageView: View {
-    var body: some View {
-        HStack {
-            Text("Interrupted")
-                .font(.system(size: 13))
-                .foregroundColor(.red)
-            Spacer()
-        }
     }
 }
 

--- a/ClaudeIsland/UI/Views/NotchMenuView.swift
+++ b/ClaudeIsland/UI/Views/NotchMenuView.swift
@@ -916,5 +916,5 @@ struct PanelWidthRow: View {
 
     @State private var isExpanded = false
     @State private var isHovered = false
-    @State private var widthFraction: Double = AppSettings.chatPanelWidthFraction
+    @State private var widthFraction: Double = min(max(AppSettings.chatPanelWidthFraction, 0.5), 0.8)
 }

--- a/ClaudeIsland/UI/Views/NotchMenuView.swift
+++ b/ClaudeIsland/UI/Views/NotchMenuView.swift
@@ -72,6 +72,8 @@ struct NotchMenuView: View {
                             self.showLayoutSettings = true
                         }
 
+                        PanelWidthRow(viewModel: self.viewModel)
+
                         Divider()
                             .background(Color.white.opacity(0.08))
                             .padding(.vertical, 4)
@@ -837,4 +839,82 @@ struct TokenTrackingRow: View {
             }
         }
     }
+}
+
+// MARK: - PanelWidthRow
+
+struct PanelWidthRow: View {
+    // MARK: Internal
+
+    var viewModel: NotchViewModel
+
+    var body: some View {
+        VStack(spacing: 0) {
+            Button {
+                withAnimation(.spring(response: 0.3, dampingFraction: 0.8)) {
+                    self.isExpanded.toggle()
+                }
+            } label: {
+                HStack(spacing: 10) {
+                    Image(systemName: "arrow.left.and.right")
+                        .font(.system(size: 12))
+                        .foregroundColor(.white.opacity(self.isHovered || self.isExpanded ? 1.0 : 0.7))
+                        .frame(width: 16)
+
+                    Text("Panel Width")
+                        .font(.system(size: 13, weight: .medium))
+                        .foregroundColor(.white.opacity(self.isHovered || self.isExpanded ? 1.0 : 0.7))
+
+                    Spacer()
+
+                    Text("\(Int(self.widthFraction * 100))%")
+                        .font(.system(size: 11))
+                        .foregroundColor(.white.opacity(0.4))
+
+                    Image(systemName: self.isExpanded ? "chevron.up" : "chevron.down")
+                        .font(.system(size: 10, weight: .medium))
+                        .foregroundColor(.white.opacity(0.4))
+                }
+                .padding(.horizontal, 12)
+                .padding(.vertical, 10)
+                .background(
+                    RoundedRectangle(cornerRadius: 8)
+                        .fill(self.isHovered || self.isExpanded ? Color.white.opacity(0.08) : Color.clear),
+                )
+            }
+            .buttonStyle(.plain)
+            .onHover { self.isHovered = $0 }
+
+            if self.isExpanded {
+                VStack(alignment: .leading, spacing: 4) {
+                    Slider(value: self.$widthFraction, in: 0.5 ... 0.8)
+                        .tint(.white.opacity(0.5))
+                        .onChange(of: self.widthFraction) { _, newValue in
+                            self.viewModel.chatPanelWidthFraction = newValue
+                            AppSettings.chatPanelWidthFraction = newValue
+                        }
+
+                    HStack {
+                        Text("50%")
+                            .font(.system(size: 10))
+                            .foregroundColor(.white.opacity(0.3))
+                        Spacer()
+                        Text("80%")
+                            .font(.system(size: 10))
+                            .foregroundColor(.white.opacity(0.3))
+                    }
+                }
+                .padding(.leading, 28)
+                .padding(.trailing, 28)
+                .padding(.vertical, 8)
+                .transition(.opacity.combined(with: .move(edge: .top)))
+            }
+        }
+    }
+
+    // MARK: Private
+
+    @State private var isExpanded = false
+    @State private var isHovered = false
+    @State private var widthFraction: Double = AppSettings.chatPanelWidthFraction
 }

--- a/ClaudeIsland/UI/Views/TerminalModeView.swift
+++ b/ClaudeIsland/UI/Views/TerminalModeView.swift
@@ -1,0 +1,76 @@
+//
+//  TerminalModeView.swift
+//  ClaudeIsland
+//
+//  Terminal mode: dense inline tool rendering with full content visible
+//
+
+import SwiftUI
+
+struct TerminalModeView: View {
+    // MARK: Internal
+
+    let item: ChatHistoryItem
+    let onApprove: (() -> Void)?
+    let onDeny: (() -> Void)?
+
+    var body: some View {
+        switch self.item.type {
+        case let .user(text):
+            self.userMessage(text)
+        case let .assistant(text):
+            self.assistantMessage(text)
+        case let .toolCall(tool):
+            ToolCallInlineView(
+                tool: tool,
+                onApprove: self.onApprove,
+                onDeny: self.onDeny,
+            )
+        case let .thinking(text):
+            if !text.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty {
+                ThinkingBlockView(text: text)
+            }
+        case .interrupted:
+            self.interruptedMessage
+        }
+    }
+
+    // MARK: Private
+
+    private let labelBlue = Color(red: 0.345, green: 0.651, blue: 1.0)
+    private let labelPurple = Color(red: 0.702, green: 0.557, blue: 0.941)
+    private let errorRed = Color(red: 0.973, green: 0.318, blue: 0.286)
+
+    private var interruptedMessage: some View {
+        Text("Interrupted")
+            .font(.system(size: 11, design: .monospaced))
+            .foregroundColor(self.errorRed)
+            .frame(maxWidth: .infinity, alignment: .leading)
+    }
+
+    private func userMessage(_ text: String) -> some View {
+        VStack(alignment: .leading, spacing: 4) {
+            Text("You")
+                .font(.system(size: 10, weight: .semibold, design: .monospaced))
+                .foregroundColor(self.labelBlue)
+
+            MarkdownText(text, color: .white.opacity(0.9), fontSize: 11)
+        }
+        .frame(maxWidth: .infinity, alignment: .leading)
+    }
+
+    private func assistantMessage(_ text: String) -> some View {
+        VStack(alignment: .leading, spacing: 4) {
+            Text("Claude")
+                .font(.system(size: 10, weight: .semibold, design: .monospaced))
+                .foregroundColor(ChatMessageHelpers.isErrorMessage(text) ? self.errorRed : self.labelPurple)
+
+            MarkdownText(
+                text,
+                color: ChatMessageHelpers.isErrorMessage(text) ? self.errorRed.opacity(0.9) : .white.opacity(0.9),
+                fontSize: 11,
+            )
+        }
+        .frame(maxWidth: .infinity, alignment: .leading)
+    }
+}

--- a/ClaudeIsland/Utilities/ChatMessageHelpers.swift
+++ b/ClaudeIsland/Utilities/ChatMessageHelpers.swift
@@ -1,0 +1,17 @@
+//
+//  ChatMessageHelpers.swift
+//  ClaudeIsland
+//
+//  Shared utilities for chat message analysis
+//
+
+import Foundation
+
+enum ChatMessageHelpers {
+    static func isErrorMessage(_ text: String) -> Bool {
+        let lowered = text.lowercased()
+        return lowered.contains("error:") || lowered.contains("api error")
+            || lowered.hasPrefix("error") || lowered.contains("failed:")
+            || lowered.contains("exception:") || lowered.contains("fatal:")
+    }
+}


### PR DESCRIPTION

## Part of larger POC merge

https://github.com/engels74/claude-island/pull/100

Part 1

## Summary
- **Dual-mode chat view** — segmented Terminal/Chat toggle in header
- **Terminal mode**: dense inline tool rendering with status dots, approval buttons, collapsible content with GeometryReader height measurement
- **Chat mode**: iMessage-style bubbles with purple avatar, compact tool summaries
- **Markdown improvements**: table rendering, task checkboxes, code block language headers with copy button, system font option
- **Configurable panel width** (50-80% via settings slider)
- **ConversationParser**: filter command-message/command-args system messages

## Review Fixes Applied
- Extracted `ChatMessageHelpers.isErrorMessage` (was duplicated in TerminalModeView + ChatModeView)
- Extracted `ToolStatusColors` enum (was duplicated in ToolCallInlineView, ToolCallSummaryView, SubagentToolRow)
- `CollapsibleContentView` uses GeometryReader + PreferenceKey for height measurement instead of rendering full content then clipping
- Fixed `@inline(__always)` syntax in NotchGeometry + SessionPhase
- Enabled `redundantSendable` SwiftFormat rule
- ProcessExecutor updated for Swift 6.2 TerminationStatus API

## Test plan
- [ ] Open chat view — verify Terminal mode renders with "You"/"Claude" labels and inline tools
- [ ] Toggle to Chat mode — verify iMessage bubbles with purple avatar
- [ ] Verify tool calls show status dots with correct colors (running=white, approval=amber, success=green, error=red)
- [ ] Verify long tool output has gradient fade with expand link
- [ ] Verify markdown tables render with alternating row colors
- [ ] Verify code blocks show language header with copy button
- [ ] Adjust panel width in settings — verify chat panel resizes
- [ ] Verify thinking blocks collapse/expand