### PR TITLE
fix: resolve Allow/Deny buttons not triggering CLI approval

### DIFF
--- a/ClaudeIsland.xcodeproj/project.pbxproj
+++ b/ClaudeIsland.xcodeproj/project.pbxproj
@@ -386,7 +386,7 @@
 			repositoryURL = "https://github.com/swiftlang/swift-subprocess";
 			requirement = {
 				kind = upToNextMajorVersion;
-				minimumVersion = 0.2.0;
+				minimumVersion = 0.4.0;
 			};
 		};
 		FD33FD712EDF32D7002A6548 /* XCRemoteSwiftPackageReference "swift-markdown" */ = {

--- a/ClaudeIsland/Core/NotchGeometry.swift
+++ b/ClaudeIsland/Core/NotchGeometry.swift
@@ -38,7 +38,7 @@ struct NotchGeometry: Sendable {
     }
 
     /// Check if a point is in the notch area (with padding for easier interaction)
-    @inline(always)
+    @inline(__always)
     func isPointInNotch(_ point: CGPoint) -> Bool {
         self.notchScreenRect.insetBy(dx: -10, dy: -5).contains(point)
     }
@@ -49,7 +49,7 @@ struct NotchGeometry: Sendable {
     }
 
     /// Check if a point is outside the opened panel (for closing)
-    @inline(always)
+    @inline(__always)
     func isPointOutsidePanel(_ point: CGPoint, size: CGSize) -> Bool {
         !self.openedScreenRect(for: size).contains(point)
     }

--- a/ClaudeIsland/Models/SessionPhase.swift
+++ b/ClaudeIsland/Models/SessionPhase.swift
@@ -97,7 +97,7 @@ nonisolated enum SessionPhase: Sendable {
     // swiftlint:disable attributes
 
     /// Whether this phase indicates the session needs user attention
-    @inline(always) var needsAttention: Bool {
+    @inline(__always) var needsAttention: Bool {
         switch self {
         case .waitingForApproval,
              .waitingForInput:
@@ -108,7 +108,7 @@ nonisolated enum SessionPhase: Sendable {
     }
 
     /// Whether this phase indicates active processing
-    @inline(always) var isActive: Bool {
+    @inline(__always) var isActive: Bool {
         switch self {
         case .processing,
              .compacting:
@@ -119,7 +119,7 @@ nonisolated enum SessionPhase: Sendable {
     }
 
     /// Whether this is a waitingForApproval phase
-    @inline(always) nonisolated var isWaitingForApproval: Bool {
+    @inline(__always) nonisolated var isWaitingForApproval: Bool {
         if case .waitingForApproval = self {
             return true
         }

--- a/ClaudeIsland/Resources/claude-island-state.py
+++ b/ClaudeIsland/Resources/claude-island-state.py
@@ -376,8 +376,10 @@ def send_event(state: SessionState, /) -> PermissionResponse | None:
                     chunks.append(chunk)
                 response = b"".join(chunks)
                 if response:
-                    _log(f"received {len(response)} bytes: {response.decode()}")
-                    parsed = cast(object, json.loads(response.decode()))
+                    _log(
+                        f"received {len(response)} bytes: {response.decode(errors='replace')}"
+                    )
+                    parsed = cast(object, json.loads(response))
                     if is_permission_response(parsed):
                         return parsed
                     _log(f"response failed validation: {parsed}")

--- a/ClaudeIsland/Resources/claude-island-state.py
+++ b/ClaudeIsland/Resources/claude-island-state.py
@@ -360,12 +360,23 @@ def send_event(state: SessionState, /) -> PermissionResponse | None:
             _log(f"connected to {SOCKET_PATH}")
             payload = json.dumps(state.to_dict()).encode()
             sock.sendall(payload)
-            _log(f"sent {len(payload)} bytes (event={state.event}, status={state.status})")
+            _log(
+                f"sent {len(payload)} bytes (event={state.event}, status={state.status})"
+            )
             if state.status == "waiting_for_approval":
                 sock.settimeout(PERMISSION_RECV_TIMEOUT_SECONDS)
                 _log("waiting for permission response...")
-                if response := sock.recv(4096):
-                    _log(f"received: {response.decode()}")
+                # Accumulate bytes until the Swift side closes the socket (EOF).
+                # SOCK_STREAM may split the JSON payload across multiple recv()
+                # calls, and longer `reason` strings can exceed a single 4KB
+                # chunk. Swift's sendPermissionResponse always close(2)s the
+                # client fd after writing, so EOF is the authoritative terminator.
+                chunks: list[bytes] = []
+                while chunk := sock.recv(4096):
+                    chunks.append(chunk)
+                response = b"".join(chunks)
+                if response:
+                    _log(f"received {len(response)} bytes: {response.decode()}")
                     parsed = cast(object, json.loads(response.decode()))
                     if is_permission_response(parsed):
                         return parsed
@@ -534,7 +545,9 @@ def main() -> None:
     # Determine status early (pure computation, no I/O)
     status, extras = determine_status(event, data)
 
-    _log(f"event={event} session={session_id[:8]} status={status} has_tool_use_id={'tool_use_id' in extras}")
+    _log(
+        f"event={event} session={session_id[:8]} status={status} has_tool_use_id={'tool_use_id' in extras}"
+    )
 
     # Skip certain events (e.g. stale PreToolUse registration)
     if status == "skip":

--- a/ClaudeIsland/Resources/claude-island-state.py
+++ b/ClaudeIsland/Resources/claude-island-state.py
@@ -38,6 +38,14 @@ from dataclasses import dataclass, field
 from pathlib import Path
 from typing import NotRequired, TypedDict, TypeIs, cast
 
+_DEBUG = os.environ.get("CLAUDE_ISLAND_DEBUG") == "1"
+
+
+def _log(msg: str, /) -> None:
+    """Log to stderr when CLAUDE_ISLAND_DEBUG=1. Does not affect stdout JSON."""
+    if _DEBUG:
+        print(f"[claude-island] {msg}", file=sys.stderr, flush=True)
+
 
 # TypedDict definitions for JSON structures
 class HookEventData(TypedDict, total=False):
@@ -349,15 +357,24 @@ def send_event(state: SessionState, /) -> PermissionResponse | None:
         with socket.socket(socket.AF_UNIX, socket.SOCK_STREAM) as sock:
             sock.settimeout(CONNECT_TIMEOUT_SECONDS)
             sock.connect(str(SOCKET_PATH))
-            sock.sendall(json.dumps(state.to_dict()).encode())
+            _log(f"connected to {SOCKET_PATH}")
+            payload = json.dumps(state.to_dict()).encode()
+            sock.sendall(payload)
+            _log(f"sent {len(payload)} bytes (event={state.event}, status={state.status})")
             if state.status == "waiting_for_approval":
                 sock.settimeout(PERMISSION_RECV_TIMEOUT_SECONDS)
+                _log("waiting for permission response...")
                 if response := sock.recv(4096):
+                    _log(f"received: {response.decode()}")
                     parsed = cast(object, json.loads(response.decode()))
                     if is_permission_response(parsed):
                         return parsed
+                    _log(f"response failed validation: {parsed}")
+                else:
+                    _log("empty response (socket closed)")
             return None
-    except OSError, json.JSONDecodeError:
+    except (OSError, json.JSONDecodeError) as exc:
+        _log(f"error: {exc}")
         return None
 
 
@@ -461,7 +478,7 @@ def handle_permission_response(response: PermissionResponse | None, /) -> None:
     """
     if not response:
         # No response or "ask" - let Claude Code show its normal UI
-        print("{}")
+        print("{}", flush=True)
         return
 
     decision = response.get("decision", "ask")
@@ -475,7 +492,8 @@ def handle_permission_response(response: PermissionResponse | None, /) -> None:
                     "decision": {"behavior": "allow"},
                 }
             }
-            print(json.dumps(output))
+            _log(f"allow -> {json.dumps(output)}")
+            print(json.dumps(output), flush=True)
             sys.exit(0)
 
         case "deny":
@@ -488,12 +506,14 @@ def handle_permission_response(response: PermissionResponse | None, /) -> None:
                     },
                 }
             }
-            print(json.dumps(output))
+            _log(f"deny -> {json.dumps(output)}")
+            print(json.dumps(output), flush=True)
             sys.exit(0)
 
         case _decision:
             # "ask" or unknown - let Claude Code show its normal UI
-            print("{}")
+            _log(f"unknown decision: {_decision}")
+            print("{}", flush=True)
 
 
 def main() -> None:
@@ -514,9 +534,11 @@ def main() -> None:
     # Determine status early (pure computation, no I/O)
     status, extras = determine_status(event, data)
 
+    _log(f"event={event} session={session_id[:8]} status={status} has_tool_use_id={'tool_use_id' in extras}")
+
     # Skip certain events (e.g. stale PreToolUse registration)
     if status == "skip":
-        print("{}")
+        print("{}", flush=True)
         sys.exit(0)
 
     # Resolve PID, TTY, build state
@@ -545,7 +567,7 @@ def main() -> None:
     if status == "waiting_for_approval":
         handle_permission_response(response)
     else:
-        print("{}")
+        print("{}", flush=True)
 
 
 if __name__ == "__main__":

--- a/ClaudeIsland/Resources/claude-island-state.py
+++ b/ClaudeIsland/Resources/claude-island-state.py
@@ -384,7 +384,7 @@ def send_event(state: SessionState, /) -> PermissionResponse | None:
                 else:
                     _log("empty response (socket closed)")
             return None
-    except (OSError, json.JSONDecodeError) as exc:
+    except (OSError, UnicodeDecodeError, json.JSONDecodeError) as exc:
         _log(f"error: {exc}")
         return None
 

--- a/ClaudeIsland/Services/Hooks/HookSocketServer.swift
+++ b/ClaudeIsland/Services/Hooks/HookSocketServer.swift
@@ -701,23 +701,31 @@ final class HookSocketServer: @unchecked Sendable { // swiftlint:disable:this ty
             guard let baseAddress = buffer.baseAddress else { return }
 
             while Date().timeIntervalSince(startTime) < 2.0 {
-                let pollResult = poll(&pollFd, 1, 10)
+                let pollResult = poll(&pollFd, 1, 100)
 
                 if pollResult > 0 && (pollFd.revents & Int16(POLLIN)) != 0 {
                     let bytesRead = read(clientSocket, baseAddress, buffer.count)
                     if bytesRead > 0 {
                         allData.append(baseAddress, count: bytesRead)
-                        if let lastByte = allData.last, lastByte == UInt8(ascii: "}") || lastByte == UInt8(ascii: "\n") {
+                        // Break only when the accumulated buffer parses as valid JSON.
+                        // A trailing '}' alone is not sufficient (nested objects end with '}'
+                        // mid-stream), so we validate the full payload. This prevents the
+                        // "Processing…" hang caused by truncating multi-packet JSON.
+                        if Self.looksLikeCompleteJSON(allData) {
                             break
                         }
                     } else if bytesRead == 0 || (errno != EAGAIN && errno != EWOULDBLOCK) {
+                        // EOF or fatal read error — stop reading.
                         break
                     }
-                } else if pollResult == 0 && !allData.isEmpty {
-                    break
-                } else if pollResult != 0 {
+                    // bytesRead < 0 with EAGAIN/EWOULDBLOCK: spurious wake, loop and poll again.
+                } else if pollResult < 0 && errno != EINTR {
+                    // Fatal poll error — stop. EINTR is retryable, fall through to loop.
                     break
                 }
+                // pollResult == 0 (quiet period): do NOT break early. Keep waiting up to the
+                // 2s hard cap so multi-packet payloads with small inter-packet gaps are not
+                // truncated. pollResult < 0 with EINTR: retry on next iteration.
             }
         }
 
@@ -727,6 +735,16 @@ final class HookSocketServer: @unchecked Sendable { // swiftlint:disable:this ty
         }
 
         return allData.isEmpty ? nil : allData
+    }
+
+    /// Cheap check for a complete JSON payload — trailing '}' plus successful decode attempt.
+    /// Returning true here is the only way `readClientData` exits before the 2s hard cap
+    /// (aside from EOF / fatal errors), so it must be strict about completeness.
+    nonisolated private static func looksLikeCompleteJSON(_ data: Data) -> Bool {
+        guard let last = data.last, last == UInt8(ascii: "}") || last == UInt8(ascii: "\n") else {
+            return false
+        }
+        return (try? JSONSerialization.jsonObject(with: data, options: [.fragmentsAllowed])) != nil
     }
 
     nonisolated private func parseHookEvent(from data: Data) -> HookEvent? {
@@ -944,24 +962,10 @@ final class HookSocketServer: @unchecked Sendable { // swiftlint:disable:this ty
                     "Sending response: \(decision, privacy: .public) for \(pending.sessionID.prefix(8), privacy: .public) tool:\(toolUseID.prefix(12), privacy: .public) (age: \(String(format: "%.1f", age), privacy: .public)s)"
                 )
 
-            var writeSuccess = false
-            var writeErrno: Int32 = 0
-            data.withUnsafeBytes { bytes in
-                guard let baseAddress = bytes.baseAddress else {
-                    Self.logger.error("Failed to get data buffer address")
-                    return
-                }
-                let writeResult = write(pending.clientSocket, baseAddress, data.count)
-                writeErrno = errno
-                if writeResult < 0 {
-                    Self.logger.error("Write failed with errno: \(writeErrno)")
-                } else if writeResult < data.count {
-                    Self.logger.warning("Partial write: \(writeResult)/\(data.count) bytes for tool:\(toolUseID.prefix(12), privacy: .public)")
-                } else {
-                    Self.logger.debug("Write succeeded: \(writeResult) bytes")
-                    writeSuccess = true
-                }
-            }
+            let writeOutcome = Self.writeAllBytes(fd: pending.clientSocket, data: data)
+            let writeSuccess = writeOutcome.success
+            let writeErrno = writeOutcome.finalErrno
+            Self.logWriteOutcome(writeOutcome, totalBytes: data.count, toolUseID: toolUseID)
 
             // Skip close if write failed with EBADF — the fd is already invalid
             // and may have been reused by another thread
@@ -1016,24 +1020,10 @@ final class HookSocketServer: @unchecked Sendable { // swiftlint:disable:this ty
                     "Sending response: \(decision, privacy: .public) for \(sessionID.prefix(8), privacy: .public) tool:\(pending.toolUseID.prefix(12), privacy: .public) (age: \(String(format: "%.1f", age), privacy: .public)s)"
                 )
 
-            var writeSuccess = false
-            var writeErrno: Int32 = 0
-            data.withUnsafeBytes { bytes in
-                guard let baseAddress = bytes.baseAddress else {
-                    Self.logger.error("Failed to get data buffer address")
-                    return
-                }
-                let writeResult = write(pending.clientSocket, baseAddress, data.count)
-                writeErrno = errno
-                if writeResult < 0 {
-                    Self.logger.error("Write failed with errno: \(writeErrno)")
-                } else if writeResult < data.count {
-                    Self.logger.warning("Partial write: \(writeResult)/\(data.count) bytes for tool:\(pending.toolUseID.prefix(12), privacy: .public)")
-                } else {
-                    Self.logger.debug("Write succeeded: \(writeResult) bytes")
-                    writeSuccess = true
-                }
-            }
+            let writeOutcome = Self.writeAllBytes(fd: pending.clientSocket, data: data)
+            let writeSuccess = writeOutcome.success
+            let writeErrno = writeOutcome.finalErrno
+            Self.logWriteOutcome(writeOutcome, totalBytes: data.count, toolUseID: pending.toolUseID)
 
             // Skip close if write failed with EBADF — the fd is already invalid
             // and may have been reused by another thread
@@ -1044,6 +1034,78 @@ final class HookSocketServer: @unchecked Sendable { // swiftlint:disable:this ty
             if !writeSuccess {
                 permissionFailureHandler?(sessionID, pending.toolUseID)
             }
+        }
+    }
+
+    // MARK: - Socket Write Helper
+
+    /// Outcome of a full-payload socket write attempt.
+    nonisolated private struct WriteOutcome: Sendable {
+        let success: Bool
+        let bytesWritten: Int
+        /// Value of `errno` at the point the loop stopped. Zero if success.
+        let finalErrno: Int32
+    }
+
+    /// Write `data` to `fd` in a loop, handling partial writes and retrying on
+    /// `EAGAIN`/`EWOULDBLOCK` (the socket is non-blocking — see `handleClient`).
+    /// Fails only on permanent errors, EOF (write returning 0), or exceeding the
+    /// 2-second cumulative budget.
+    nonisolated private static func writeAllBytes(fd: Int32, data: Data) -> WriteOutcome {
+        let totalBytes = data.count
+        guard totalBytes > 0 else { return WriteOutcome(success: true, bytesWritten: 0, finalErrno: 0) }
+
+        var totalWritten = 0
+        var lastErrno: Int32 = 0
+        let deadline = Date().addingTimeInterval(2.0)
+
+        data.withUnsafeBytes { bytes in
+            guard let baseAddress = bytes.baseAddress else {
+                lastErrno = EFAULT
+                return
+            }
+            while totalWritten < totalBytes {
+                let remaining = totalBytes - totalWritten
+                let cursor = baseAddress.advanced(by: totalWritten)
+                let n = write(fd, cursor, remaining)
+                if n > 0 {
+                    totalWritten += n
+                    continue
+                }
+                lastErrno = errno
+                if n == 0 {
+                    // write() returning 0 on a stream socket is unusual; treat as failure.
+                    break
+                }
+                // n < 0
+                if lastErrno == EINTR {
+                    continue
+                }
+                if lastErrno == EAGAIN || lastErrno == EWOULDBLOCK {
+                    if Date() >= deadline { break }
+                    var pollFd = pollfd(fd: fd, events: Int16(POLLOUT), revents: 0)
+                    // Short poll so we honor the overall deadline without long stalls.
+                    let pollResult = poll(&pollFd, 1, 100)
+                    if pollResult < 0, errno != EINTR { lastErrno = errno; break }
+                    continue
+                }
+                break
+            }
+        }
+
+        let success = totalWritten == totalBytes
+        return WriteOutcome(success: success, bytesWritten: totalWritten, finalErrno: success ? 0 : lastErrno)
+    }
+
+    nonisolated private static func logWriteOutcome(_ outcome: WriteOutcome, totalBytes: Int, toolUseID: String) {
+        if outcome.success {
+            Self.logger.debug("Write succeeded: \(outcome.bytesWritten) bytes")
+        } else if outcome.bytesWritten == 0 {
+            Self.logger.error("Write failed with errno: \(outcome.finalErrno)")
+        } else {
+            Self.logger.error(
+                "Partial write \(outcome.bytesWritten)/\(totalBytes) bytes (errno: \(outcome.finalErrno)) for tool:\(toolUseID.prefix(12), privacy: .public)"
+            )
         }
     }
 }

--- a/ClaudeIsland/Services/Hooks/HookSocketServer.swift
+++ b/ClaudeIsland/Services/Hooks/HookSocketServer.swift
@@ -566,6 +566,7 @@ final class HookSocketServer: @unchecked Sendable { // swiftlint:disable:this ty
                     Self.logger.info("Skipping cleanup of recent permission (age: \(String(format: "%.1f", age), privacy: .public)s) for \(sessionID.prefix(8), privacy: .public) tool:\(toolUseID.prefix(12), privacy: .public)")
                 } else {
                     state.pendingPermissions.removeValue(forKey: toolUseID)
+                    Self.markPermissionResponded(in: &state, toolUseID: toolUseID, maxCount: maxRespondedPermissions)
                     toClose.append((toolUseID, pending))
                 }
             }

--- a/ClaudeIsland/Services/Hooks/HookSocketServer.swift
+++ b/ClaudeIsland/Services/Hooks/HookSocketServer.swift
@@ -555,21 +555,21 @@ final class HookSocketServer: @unchecked Sendable { // swiftlint:disable:this ty
 
     nonisolated private func cleanupPendingPermissions(sessionID: String) {
         let now = Date()
-        let result = permissionsState.withLock { state -> (toClose: [(String, PendingPermission)], skipped: Int) in
+        let result = permissionsState.withLock { state -> (toClose: [(String, PendingPermission)], deferred: [(String, TimeInterval)]) in
             let matching = state.pendingPermissions.filter { $0.value.sessionID == sessionID }
             var toClose: [(String, PendingPermission)] = []
-            var skipped = 0
+            var deferred: [(String, TimeInterval)] = []
             for (toolUseID, pending) in matching {
                 let age = now.timeIntervalSince(pending.receivedAt)
                 if age < 2.0 {
-                    skipped += 1
+                    deferred.append((toolUseID, age))
                     Self.logger.info("Skipping cleanup of recent permission (age: \(String(format: "%.1f", age), privacy: .public)s) for \(sessionID.prefix(8), privacy: .public) tool:\(toolUseID.prefix(12), privacy: .public)")
                 } else {
                     state.pendingPermissions.removeValue(forKey: toolUseID)
                     toClose.append((toolUseID, pending))
                 }
             }
-            return (toClose, skipped)
+            return (toClose, deferred)
         }
 
         for (toolUseID, pending) in result.toClose {
@@ -577,6 +577,37 @@ final class HookSocketServer: @unchecked Sendable { // swiftlint:disable:this ty
             Self.logger.debug("Cleaning up stale permission for \(sessionID.prefix(8), privacy: .public) tool:\(toolUseID.prefix(12), privacy: .public)")
             close(pending.clientSocket)
         }
+
+        // Re-schedule cleanup for permissions we skipped above so a cancelled session
+        // doesn't leave the Python hook blocked on its 300s recv timeout.
+        for (toolUseID, age) in result.deferred {
+            let delay = max(2.0 - age, 0.1)
+            queue.asyncAfter(deadline: .now() + delay) { [weak self] in
+                self?.cleanupPendingPermissionsRetry(sessionID: sessionID, toolUseID: toolUseID)
+            }
+        }
+    }
+
+    /// Follow-up cleanup for a specific permission whose initial cleanup was skipped
+    /// because it was younger than the 2-second grace window. Idempotent — no-ops if
+    /// the permission has already been resolved or re-scheduled.
+    nonisolated private func cleanupPendingPermissionsRetry(sessionID: String, toolUseID: String) {
+        let pending = permissionsState.withLock { state -> PendingPermission? in
+            guard let existing = state.pendingPermissions[toolUseID],
+                  existing.sessionID == sessionID
+            else {
+                return nil
+            }
+            state.pendingPermissions.removeValue(forKey: toolUseID)
+            Self.markPermissionResponded(in: &state, toolUseID: toolUseID, maxCount: maxRespondedPermissions)
+            return existing
+        }
+
+        guard let pending else { return }
+        pending.disconnectSource?.cancel()
+        Self.logger.debug("Deferred cleanup of stale permission for \(sessionID.prefix(8), privacy: .public) tool:\(toolUseID.prefix(12), privacy: .public)")
+        close(pending.clientSocket)
+        permissionFailureHandler?(sessionID, toolUseID)
     }
 
     /// Generate cache key from event properties
@@ -719,6 +750,10 @@ final class HookSocketServer: @unchecked Sendable { // swiftlint:disable:this ty
                         break
                     }
                     // bytesRead < 0 with EAGAIN/EWOULDBLOCK: spurious wake, loop and poll again.
+                } else if pollResult > 0 && (pollFd.revents & Int16(POLLHUP | POLLERR | POLLNVAL)) != 0 {
+                    // Peer closed (HUP) or socket error (ERR/NVAL) without readable data —
+                    // break promptly to avoid spinning on an immediately-returning poll().
+                    break
                 } else if pollResult < 0 && errno != EINTR {
                     // Fatal poll error — stop. EINTR is retryable, fall through to loop.
                     break
@@ -1072,11 +1107,14 @@ final class HookSocketServer: @unchecked Sendable { // swiftlint:disable:this ty
                     totalWritten += n
                     continue
                 }
-                lastErrno = errno
                 if n == 0 {
-                    // write() returning 0 on a stream socket is unusual; treat as failure.
+                    // write() returning 0 on a stream socket is unusual and does not
+                    // set errno meaningfully. Surface an explicit EIO so logs show a
+                    // diagnosable code instead of a stale/zero value.
+                    lastErrno = EIO
                     break
                 }
+                lastErrno = errno
                 // n < 0
                 if lastErrno == EINTR {
                     continue

--- a/ClaudeIsland/Services/Hooks/HookSocketServer.swift
+++ b/ClaudeIsland/Services/Hooks/HookSocketServer.swift
@@ -295,6 +295,7 @@ final class HookSocketServer: @unchecked Sendable { // swiftlint:disable:this ty
 
     /// Respond to a pending permission request by toolUseID
     nonisolated func respondToPermission(toolUseID: String, decision: String, reason: String? = nil) {
+        Self.logger.info("respondToPermission called: tool:\(toolUseID.prefix(12), privacy: .public) decision:\(decision, privacy: .public)")
         queue.async { [weak self] in
             self?.sendPermissionResponse(toolUseID: toolUseID, decision: decision, reason: reason)
         }
@@ -553,15 +554,25 @@ final class HookSocketServer: @unchecked Sendable { // swiftlint:disable:this ty
     }
 
     nonisolated private func cleanupPendingPermissions(sessionID: String) {
-        let permissionsToClose = permissionsState.withLock { state -> [(String, PendingPermission)] in
+        let now = Date()
+        let result = permissionsState.withLock { state -> (toClose: [(String, PendingPermission)], skipped: Int) in
             let matching = state.pendingPermissions.filter { $0.value.sessionID == sessionID }
-            for (toolUseID, _) in matching {
-                state.pendingPermissions.removeValue(forKey: toolUseID)
+            var toClose: [(String, PendingPermission)] = []
+            var skipped = 0
+            for (toolUseID, pending) in matching {
+                let age = now.timeIntervalSince(pending.receivedAt)
+                if age < 2.0 {
+                    skipped += 1
+                    Self.logger.info("Skipping cleanup of recent permission (age: \(String(format: "%.1f", age), privacy: .public)s) for \(sessionID.prefix(8), privacy: .public) tool:\(toolUseID.prefix(12), privacy: .public)")
+                } else {
+                    state.pendingPermissions.removeValue(forKey: toolUseID)
+                    toClose.append((toolUseID, pending))
+                }
             }
-            return matching.map { ($0.key, $0.value) }
+            return (toClose, skipped)
         }
 
-        for (toolUseID, pending) in permissionsToClose {
+        for (toolUseID, pending) in result.toClose {
             pending.disconnectSource?.cancel()
             Self.logger.debug("Cleaning up stale permission for \(sessionID.prefix(8), privacy: .public) tool:\(toolUseID.prefix(12), privacy: .public)")
             close(pending.clientSocket)
@@ -689,13 +700,16 @@ final class HookSocketServer: @unchecked Sendable { // swiftlint:disable:this ty
         withUnsafeTemporaryAllocation(of: UInt8.self, capacity: 131_072) { buffer in
             guard let baseAddress = buffer.baseAddress else { return }
 
-            while Date().timeIntervalSince(startTime) < 0.2 {
+            while Date().timeIntervalSince(startTime) < 2.0 {
                 let pollResult = poll(&pollFd, 1, 10)
 
                 if pollResult > 0 && (pollFd.revents & Int16(POLLIN)) != 0 {
                     let bytesRead = read(clientSocket, baseAddress, buffer.count)
                     if bytesRead > 0 {
                         allData.append(baseAddress, count: bytesRead)
+                        if let lastByte = allData.last, lastByte == UInt8(ascii: "}") || lastByte == UInt8(ascii: "\n") {
+                            break
+                        }
                     } else if bytesRead == 0 || (errno != EAGAIN && errno != EWOULDBLOCK) {
                         break
                     }
@@ -705,6 +719,11 @@ final class HookSocketServer: @unchecked Sendable { // swiftlint:disable:this ty
                     break
                 }
             }
+        }
+
+        let elapsed = Date().timeIntervalSince(startTime)
+        if elapsed > 0.5 && !allData.isEmpty {
+            Self.logger.info("Slow client read: \(allData.count) bytes in \(String(format: "%.1f", elapsed), privacy: .public)s")
         }
 
         return allData.isEmpty ? nil : allData
@@ -731,11 +750,12 @@ final class HookSocketServer: @unchecked Sendable { // swiftlint:disable:this ty
     }
 
     nonisolated private func handlePermissionRequest(event: HookEvent, clientSocket: Int32, eventHandler: HookEventHandler?) {
-        guard let toolUseID = resolveToolUseID(for: event) else {
-            Self.logger.warning("Permission request missing tool_use_id for \(event.sessionID.prefix(8), privacy: .public) - no cache hit")
-            close(clientSocket)
-            eventHandler?(event)
-            return
+        let toolUseID: String
+        if let resolved = resolveToolUseID(for: event) {
+            toolUseID = resolved
+        } else {
+            toolUseID = UUID().uuidString
+            Self.logger.warning("Permission request missing tool_use_id for \(event.sessionID.prefix(8), privacy: .public) - generated fallback: \(toolUseID.prefix(12), privacy: .public)")
         }
 
         Self.logger.debug("Permission request - keeping socket open for \(event.sessionID.prefix(8), privacy: .public) tool:\(toolUseID.prefix(12), privacy: .public)")
@@ -831,8 +851,9 @@ final class HookSocketServer: @unchecked Sendable { // swiftlint:disable:this ty
         }
 
         guard let pending else { return }
+        let age = Date().timeIntervalSince(pending.receivedAt)
         pending.disconnectSource?.cancel()
-        Self.logger.info("Python socket closed for \(sessionID.prefix(8), privacy: .public) tool:\(toolUseID.prefix(12), privacy: .public) — cleaning up stale permission")
+        Self.logger.warning("Python socket closed for \(sessionID.prefix(8), privacy: .public) tool:\(toolUseID.prefix(12), privacy: .public) after \(String(format: "%.1f", age), privacy: .public)s — cleaning up stale permission")
         close(pending.clientSocket)
         permissionFailureHandler?(sessionID, toolUseID)
     }
@@ -899,10 +920,14 @@ final class HookSocketServer: @unchecked Sendable { // swiftlint:disable:this ty
 
         switch result {
         case .alreadyResponded:
-            Self.logger.debug("Permission already responded for toolUseId: \(toolUseID.prefix(12), privacy: .public) - skipping duplicate")
+            Self.logger.info("Permission already responded for toolUseId: \(toolUseID.prefix(12), privacy: .public) - skipping duplicate")
             return
         case .notFound:
-            Self.logger.debug("No pending permission for toolUseId: \(toolUseID.prefix(12), privacy: .public)")
+            let pendingCount = permissionsState.withLock { $0.pendingPermissions.count }
+            let pendingIDs = permissionsState.withLock { state in
+                state.pendingPermissions.keys.map { String($0.prefix(12)) }.joined(separator: ", ")
+            }
+            Self.logger.warning("No pending permission for toolUseId: \(toolUseID.prefix(12), privacy: .public) (pending count: \(pendingCount), IDs: [\(pendingIDs, privacy: .public)])")
             return
         case let .found(pending):
             pending.disconnectSource?.cancel()
@@ -930,6 +955,8 @@ final class HookSocketServer: @unchecked Sendable { // swiftlint:disable:this ty
                 writeErrno = errno
                 if writeResult < 0 {
                     Self.logger.error("Write failed with errno: \(writeErrno)")
+                } else if writeResult < data.count {
+                    Self.logger.warning("Partial write: \(writeResult)/\(data.count) bytes for tool:\(toolUseID.prefix(12), privacy: .public)")
                 } else {
                     Self.logger.debug("Write succeeded: \(writeResult) bytes")
                     writeSuccess = true
@@ -1000,6 +1027,8 @@ final class HookSocketServer: @unchecked Sendable { // swiftlint:disable:this ty
                 writeErrno = errno
                 if writeResult < 0 {
                     Self.logger.error("Write failed with errno: \(writeErrno)")
+                } else if writeResult < data.count {
+                    Self.logger.warning("Partial write: \(writeResult)/\(data.count) bytes for tool:\(pending.toolUseID.prefix(12), privacy: .public)")
                 } else {
                     Self.logger.debug("Write succeeded: \(writeResult) bytes")
                     writeSuccess = true

--- a/ClaudeIsland/Services/Hooks/HookSocketServer.swift
+++ b/ClaudeIsland/Services/Hooks/HookSocketServer.swift
@@ -661,7 +661,7 @@ final class HookSocketServer: @unchecked Sendable { // swiftlint:disable:this ty
         let handler = eventHandler
 
         // Dispatch client handling off the accept queue to prevent head-of-line blocking.
-        // readClientData polls for up to 200ms — running it here would block new connections.
+        // readClientData polls for up to 2s — running it here would block new connections.
         clientQueue.async { [weak self] in
             self?.handleClient(clientSocket, eventHandler: handler)
         }

--- a/ClaudeIsland/Services/Hooks/HookSocketServer.swift
+++ b/ClaudeIsland/Services/Hooks/HookSocketServer.swift
@@ -591,6 +591,12 @@ final class HookSocketServer: @unchecked Sendable { // swiftlint:disable:this ty
     /// Follow-up cleanup for a specific permission whose initial cleanup was skipped
     /// because it was younger than the 2-second grace window. Idempotent — no-ops if
     /// the permission has already been resolved or re-scheduled.
+    ///
+    /// Mirrors the main `cleanupPendingPermissions` path: silently closes the FD without
+    /// invoking `permissionFailureHandler`. The phase transition is driven by the Stop
+    /// hook event that triggered this cleanup; firing `permissionSocketFailed` here would
+    /// race with and potentially override that phase (e.g. transition `.idle` back to
+    /// `.waitingForApproval` if another pending tool exists in the chat history).
     nonisolated private func cleanupPendingPermissionsRetry(sessionID: String, toolUseID: String) {
         let pending = permissionsState.withLock { state -> PendingPermission? in
             guard let existing = state.pendingPermissions[toolUseID],
@@ -607,7 +613,6 @@ final class HookSocketServer: @unchecked Sendable { // swiftlint:disable:this ty
         pending.disconnectSource?.cancel()
         Self.logger.debug("Deferred cleanup of stale permission for \(sessionID.prefix(8), privacy: .public) tool:\(toolUseID.prefix(12), privacy: .public)")
         close(pending.clientSocket)
-        permissionFailureHandler?(sessionID, toolUseID)
     }
 
     /// Generate cache key from event properties
@@ -745,8 +750,14 @@ final class HookSocketServer: @unchecked Sendable { // swiftlint:disable:this ty
                         if Self.looksLikeCompleteJSON(allData) {
                             break
                         }
-                    } else if bytesRead == 0 || (errno != EAGAIN && errno != EWOULDBLOCK) {
-                        // EOF or fatal read error — stop reading.
+                    } else if bytesRead == 0 {
+                        // EOF — remote closed, stop reading.
+                        break
+                    } else if errno == EINTR {
+                        // Interrupted by signal — retry (symmetric with poll() EINTR handling).
+                        continue
+                    } else if errno != EAGAIN && errno != EWOULDBLOCK {
+                        // Fatal read error — stop reading.
                         break
                     }
                     // bytesRead < 0 with EAGAIN/EWOULDBLOCK: spurious wake, loop and poll again.

--- a/ClaudeIsland/Services/Shared/ProcessExecutor.swift
+++ b/ClaudeIsland/Services/Shared/ProcessExecutor.swift
@@ -112,7 +112,7 @@ nonisolated struct ProcessExecutor: ProcessExecuting, Sendable {
             // For signals, use Unix convention: 128 + signal number (e.g., SIGTERM=15 → 143, SIGKILL=9 → 137)
             let exitCode: Int32 = switch result.terminationStatus {
             case let .exited(code): code
-            case let .unhandledException(signal): 128 + signal
+            case let .signaled(signal): 128 + signal
             }
 
             let processResult = ProcessResult(

--- a/ClaudeIsland/Services/Shared/ProcessExecutor.swift
+++ b/ClaudeIsland/Services/Shared/ProcessExecutor.swift
@@ -112,7 +112,7 @@ nonisolated struct ProcessExecutor: ProcessExecuting, Sendable {
             // For signals, use Unix convention: 128 + signal number (e.g., SIGTERM=15 → 143, SIGKILL=9 → 137)
             let exitCode: Int32 = switch result.terminationStatus {
             case let .exited(code): code
-            case let .signaled(signal): 128 + signal
+            case let .unhandledException(signal): 128 + signal
             }
 
             let processResult = ProcessResult(


### PR DESCRIPTION
## Summary

Fixes #98 - Allow/Deny buttons in the notch UI transition to "Processing..." but never trigger approval in the CLI.

**Root cause:** When `tool_use_id` is missing from a `PermissionRequest` hook event, `handlePermissionRequest` closes the socket but still dispatches the event to the UI. The user sees buttons that can never send a response back.

**Four fixes applied:**

- **Fallback UUID generation** — When `resolveToolUseID` returns nil, generate a UUID instead of closing the socket. The permission flow completes normally with the synthetic ID.
- **Increased socket read window** — Extended from 200ms to 2s with early exit on complete JSON (`}` or `\n`). Prevents truncated reads on large `tool_input` payloads.
- **Python stdout flush** — Added `flush=True` to all `print()` calls that output JSON to stdout, ensuring `hookSpecificOutput` reaches Claude Code without buffering delays. Also fixed an `except` syntax error (`OSError, json.JSONDecodeError` -> `(OSError, json.JSONDecodeError)`).
- **Cleanup race guard** — Permissions less than 2 seconds old are skipped during `cleanupPendingPermissions`, preventing Stop/SessionEnd events from racing with user approval clicks.

**Also includes:**
- Enhanced diagnostic logging (`.warning` level for failures, pending permission count/IDs on `.notFound`)
- Conditional Python stderr logging via `CLAUDE_ISLAND_DEBUG=1` env var
- Build compatibility fixes: `@inline(always)` -> `@inline(__always)`, `.signaled` -> `.unhandledException`

## Testing

- Reproduced the bug locally (WARP terminal, macOS Tahoe)
- Applied fixes, rebuilt, confirmed clicking Allow in the notch successfully approves the tool in the CLI
- Issue reporters confirmed the bug on both iTerm2 and Terminal.app

## Test plan

- [ ] Build the app (`./scripts/build.sh`)
- [ ] Start a Claude Code session with manual approval required
- [ ] Trigger a tool permission (e.g., file edit)
- [ ] Click Allow in the notch — CLI should proceed
- [ ] Click Deny in the notch — CLI should show denial
- [ ] Set `CLAUDE_ISLAND_DEBUG=1` and verify stderr diagnostic output